### PR TITLE
images: Allow to specify img size

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jq . < _data/images.json
   {
     "name": "k8s",
     "parent": "base",
+    "image_size": "20G",
     "packages": [
       "docker.io"
     ]

--- a/pkg/images/conf.go
+++ b/pkg/images/conf.go
@@ -6,6 +6,8 @@ type ImgConf struct {
 	Name string `json:"name"`
 	// Parent is the name parent image (or "" if image does not have a parent)
 	Parent string `json:"parent,omitempty"`
+	// ImageSize is the size of the image (defaults to images.DefaultImageSize)
+	ImageSize string `json:"image_size,omitempty"`
 	// Packages is the list of packages contained in the image
 	Packages []string `json:"packages"`
 	// Actions is a list of additional actions for building the image.

--- a/pkg/images/step_create_image.go
+++ b/pkg/images/step_create_image.go
@@ -90,6 +90,11 @@ func (s *CreateImage) makeRootImage(ctx context.Context) error {
 		}
 	}()
 
+	imgSize := DefaultImageSize
+	if size := s.imgCnf.ImageSize; size != "" {
+		imgSize = size
+	}
+
 	// example: guestfish -N foo.img=disk:8G -- mkfs ext4 /dev/sda : mount /dev/sda / : tar-in /tmp/foo.tar /
 	if s.bootable {
 		dirname, err := os.MkdirTemp("", "extlinux-")
@@ -105,7 +110,7 @@ func (s *CreateImage) makeRootImage(ctx context.Context) error {
 		}
 
 		cmd = exec.CommandContext(ctx, GuestFish,
-			"-N", fmt.Sprintf("%s=disk:%s", imgFname, DefaultImageSize),
+			"-N", fmt.Sprintf("%s=disk:%s", imgFname, imgSize),
 			"--",
 			"part-disk", "/dev/sda", "mbr",
 			":",
@@ -123,7 +128,7 @@ func (s *CreateImage) makeRootImage(ctx context.Context) error {
 		)
 	} else {
 		cmd = exec.CommandContext(ctx, GuestFish,
-			"-N", fmt.Sprintf("%s=disk:%s", imgFname, DefaultImageSize),
+			"-N", fmt.Sprintf("%s=disk:%s", imgFname, imgSize),
 			"--",
 			"mkfs", "ext4", "/dev/sda",
 			":",


### PR DESCRIPTION
Apparently, the 8G default is not enough when running Kind + Cilium +
"cilium connectivity test".