### PR TITLE
runner: Added VM runner

### DIFF
--- a/cmd/lvh/main.go
+++ b/cmd/lvh/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/cilium/little-vm-helper/cmd/lvh/images"
 	"github.com/cilium/little-vm-helper/cmd/lvh/kernels"
+	"github.com/cilium/little-vm-helper/cmd/lvh/runner"
 
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,7 @@ func init() {
 	rootCmd.AddCommand(
 		images.ImagesCommand(),
 		kernels.KernelsCommand(),
+		runner.RunCommand(),
 	)
 }
 

--- a/cmd/lvh/runner/conf.go
+++ b/cmd/lvh/runner/conf.go
@@ -1,0 +1,36 @@
+package runner
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type RunConf struct {
+	// Image filename
+	Image string
+	// kernel filename to boot with. (if empty no -kernel option will be passed to qemu)
+	KernelFname string
+	// Do not run the qemu command, just print it
+	QemuPrint bool
+	// Do not use KVM acceleration, even if /dev/kvm exists
+	DisableKVM bool
+	// Daemonize QEMU after initializing
+	Daemonize bool
+
+	// Disable the network connection to the VM
+	DisableNetwork bool
+	ForwardedPorts []PortForward
+
+	Logger *logrus.Logger
+
+	HostMount string
+}
+
+func (rc *RunConf) testImageFname() string {
+	return rc.Image
+}
+
+type PortForward struct {
+	HostPort int
+	VMPort   int
+	Protocol string
+}

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -1,0 +1,77 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
+	qemuArgs := []string{
+		// no need for all the default devices
+		"-nodefaults",
+		// no need display (-nographics seems a bit slower)
+		"-display", "none",
+		// don't reboot, just exit
+		"-no-reboot",
+		// cpus, memory
+		"-smp", "2", "-m", "4G",
+	}
+
+	// quick-and-dirty kvm detection
+	if !rcnf.DisableKVM {
+		if f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0755); err == nil {
+			qemuArgs = append(qemuArgs, "-enable-kvm", "-cpu", "kvm64")
+			f.Close()
+		} else {
+			log.Info("KVM disabled")
+		}
+	}
+
+	qemuArgs = append(qemuArgs,
+		"-hda", rcnf.testImageFname(),
+	)
+
+	if rcnf.KernelFname != "" {
+		appendArgs := []string{
+			"root=/dev/sda",
+			"console=ttyS0",
+			"earlyprintk=ttyS0",
+			"panic=-1",
+		}
+		qemuArgs = append(qemuArgs,
+			"-kernel", rcnf.KernelFname,
+			"-append", fmt.Sprintf("%s", strings.Join(appendArgs, " ")),
+		)
+	}
+
+	if !rcnf.DisableNetwork {
+		netdev := "user,id=user.0"
+		for _, fwd := range rcnf.ForwardedPorts {
+			netdev = fmt.Sprintf("%s,hostfwd=%s::%d-:%d", netdev, fwd.Protocol, fwd.HostPort, fwd.VMPort)
+		}
+
+		qemuArgs = append(qemuArgs,
+			"-netdev", netdev,
+			"-device", "virtio-net-pci,netdev=user.0",
+		)
+	}
+
+	if !rcnf.Daemonize {
+		qemuArgs = append(qemuArgs,
+			"-serial", "mon:stdio",
+			"-device", "virtio-serial-pci",
+		)
+	} else {
+		qemuArgs = append(qemuArgs, "-daemonize")
+	}
+
+	qemuArgs = append(qemuArgs,
+		"-fsdev", fmt.Sprintf("local,id=host_id,path=%s,security_model=none", rcnf.HostMount),
+		"-device", "virtio-9p-pci,fsdev=host_id,mount_tag=host_mount",
+	)
+
+	return qemuArgs, nil
+}

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -1,0 +1,146 @@
+package runner
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	rcnf RunConf
+
+	ports []string
+)
+
+func RunCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "run",
+		Short:        "run/start VMs based on generated base images and kernels",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+
+			rcnf.Logger = logrus.New()
+
+			rcnf.ForwardedPorts, err = parsePorts(ports)
+			if err != nil {
+				return fmt.Errorf("Port flags: %w", err)
+			}
+
+			t0 := time.Now()
+
+			err = StartQemu(rcnf)
+			dur := time.Since(t0).Round(time.Millisecond)
+			fmt.Printf("Execution took %v\n", dur)
+			if err != nil {
+				return fmt.Errorf("Qemu exited with an error: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&rcnf.Image, "image", "", "VM image file path")
+	cmd.MarkFlagRequired("image")
+	cmd.Flags().StringVar(&rcnf.KernelFname, "kernel", "", "kernel filename to boot with. (if empty no -kernel option will be passed to qemu)")
+	cmd.Flags().BoolVar(&rcnf.QemuPrint, "qemu-cmd-print", false, "Do not run the qemu command, just print it")
+	cmd.Flags().BoolVar(&rcnf.DisableKVM, "qemu-disable-kvm", false, "Do not use KVM acceleration, even if /dev/kvm exists")
+	cmd.Flags().BoolVar(&rcnf.Daemonize, "daemonize", false, "daemonize QEMU after initializing")
+	cmd.Flags().StringVar(&rcnf.HostMount, "host-mount", "", "Mount the specified host directory in the VM using a 'host_mount' tag")
+	cmd.Flags().StringArrayVarP(&ports, "port", "p", nil, "Forward a port (hostport[:vmport[:tcp|udp]])")
+
+	return cmd
+}
+
+func parsePorts(flags []string) ([]PortForward, error) {
+	var forwards []PortForward
+	for _, flag := range flags {
+		hostPortStr, vmPortAndProto, found := strings.Cut(flag, ":")
+		if !found {
+			hostPort, err := strconv.Atoi(flag)
+			if err != nil {
+				return nil, fmt.Errorf("'%s' is not a valid port number", flag)
+			}
+			forwards = append(forwards, PortForward{
+				HostPort: hostPort,
+				VMPort:   hostPort,
+				Protocol: "tcp",
+			})
+			continue
+		}
+
+		hostPort, err := strconv.Atoi(hostPortStr)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' is not a valid port number", hostPortStr)
+		}
+
+		vmPortStr, proto, found := strings.Cut(vmPortAndProto, ":")
+		if !found {
+			vmPort, err := strconv.Atoi(vmPortAndProto)
+			if err != nil {
+				return nil, fmt.Errorf("'%s' is not a valid port number", vmPortAndProto)
+			}
+			forwards = append(forwards, PortForward{
+				HostPort: hostPort,
+				VMPort:   vmPort,
+				Protocol: "tcp",
+			})
+			continue
+		}
+
+		vmPort, err := strconv.Atoi(vmPortStr)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' is not a valid port number", vmPortStr)
+		}
+
+		proto = strings.ToLower(proto)
+		if proto != "tcp" && proto != "udp" {
+			return nil, fmt.Errorf("port forward protocol must be tcp or udp")
+		}
+
+		forwards = append(forwards, PortForward{
+			HostPort: hostPort,
+			VMPort:   vmPort,
+			Protocol: proto,
+		})
+	}
+
+	return forwards, nil
+}
+
+const qemuBin = "qemu-system-x86_64"
+
+func StartQemu(rcnf RunConf) error {
+	qemuArgs, err := BuildQemuArgs(rcnf.Logger, &rcnf)
+	if err != nil {
+		return err
+	}
+
+	if rcnf.QemuPrint {
+		var sb strings.Builder
+		sb.WriteString(qemuBin)
+		for _, arg := range qemuArgs {
+			sb.WriteString(" ")
+			if len(arg) > 0 && arg[0] == '-' {
+				sb.WriteString("\\\n\t")
+			}
+			sb.WriteString(arg)
+		}
+
+		fmt.Printf("%s\n", sb.String())
+		return nil
+	}
+
+	qemuPath, err := exec.LookPath(qemuBin)
+	if err != nil {
+		return err
+	}
+
+	return unix.Exec(qemuPath, append([]string{qemuBin}, qemuArgs...), nil)
+}

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail


### PR DESCRIPTION
This commit add the `lvh run` command, which is a generalized version
of the Tetragon runner. It is essentially a small wrapper around qemu
to aid in setting the correct attributes to make it run. It modifies the
base image in its current iteration to add test scripts and systemd
services.

HOWTO run it:

        mkdir images
        docker run -v $(pwd)/images:/mnt/images \
            quay.io/lvh-images/root-images:latest \
            cp /data/images/kind.qcow2.zst /mnt/images
        cd images
        zstd -d kind.qcow2.zst && cd ..
        go run ./cmd/lvh run --image images/cilium.qcow2 \
            --mount ~/sandbox/gopath/src/github.com/cilium/ \
            --daemonize -p 2222:22
        ssh -p 2222 -o "StrictHostKeyChecking=no" root@localhost
        # hack hack