### PR TITLE
make: Statically link lvh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ GO ?= go
 OCIREPO ?= quay.io/lvh-images/lvh
 DOCKER ?= docker
 
-all: tests little-vm-helper 
+all: tests little-vm-helper
 
 .PHONY: tests
 tests:
 	$(GO) test -cover ./...
 
 little-vm-helper: FORCE
-	$(GO) build ./cmd/lvh
+	CGO_ENABLED=0 $(GO) build ./cmd/lvh
 
 .PHONY: image
 image:


### PR DESCRIPTION
Then the executable can be extracted from the Docker LVH image.

Signed-off-by: Martynas Pumputis <m@lambda.lt>