### PR TITLE
subcommands/run: add a flag to change cpu kind

### DIFF
--- a/cmd/lvh/runner/conf.go
+++ b/cmd/lvh/runner/conf.go
@@ -28,6 +28,8 @@ type RunConf struct {
 
 	CPU int
 	Mem string
+	// Kind of CPU to use (e.g. host or kvm64)
+	CPUKind string
 }
 
 func (rc *RunConf) testImageFname() string {

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -23,7 +23,7 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 	// quick-and-dirty kvm detection
 	if !rcnf.DisableKVM {
 		if f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0755); err == nil {
-			qemuArgs = append(qemuArgs, "-enable-kvm", "-cpu", "kvm64")
+			qemuArgs = append(qemuArgs, "-enable-kvm", "-cpu", rcnf.CPUKind)
 			f.Close()
 		} else {
 			log.Info("KVM disabled")

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -57,6 +57,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().IntVar(&rcnf.SerialPort, "serial-port", 0, "Port for serial console")
 	cmd.Flags().IntVar(&rcnf.CPU, "cpu", 2, "CPU count (-smp)")
 	cmd.Flags().StringVar(&rcnf.Mem, "mem", "4G", "RAM size (-m)")
+	cmd.Flags().StringVar(&rcnf.CPUKind, "cpu-kind", "kvm64", "CPU kind to use (-cpu), has no effect when KVM is disabled")
 
 	return cmd
 }


### PR DESCRIPTION
This commit adds a new flag to change CPU kind (the -cpu flag in qemu). This way we can pass different types as needed, for example "host" to get a slight performance boost. Default to kvm64 as it provides the strongest compatibility guarantees and mirrors the old behaviour.

Signed-off-by: William Findlay <will@isovalent.com>