### PR TITLE
Add an option to enable TCP-based QEMU monitor port

### DIFF
--- a/cmd/lvh/runner/conf.go
+++ b/cmd/lvh/runner/conf.go
@@ -30,6 +30,8 @@ type RunConf struct {
 	Mem string
 	// Kind of CPU to use (e.g. host or kvm64)
 	CPUKind string
+
+	QemuMonitorPort int
 }
 
 func (rc *RunConf) testImageFname() string {

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -74,6 +74,11 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 		qemuArgs = append(qemuArgs, "-daemonize")
 	}
 
+	if rcnf.QemuMonitorPort != 0 {
+		arg := fmt.Sprintf("tcp:localhost:%d,server,nowait", rcnf.QemuMonitorPort)
+		qemuArgs = append(qemuArgs, "-monitor", arg)
+	}
+
 	qemuArgs = append(qemuArgs,
 		"-fsdev", fmt.Sprintf("local,id=host_id,path=%s,security_model=none", rcnf.HostMount),
 		"-device", "virtio-9p-pci,fsdev=host_id,mount_tag=host_mount",

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -58,6 +58,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().IntVar(&rcnf.CPU, "cpu", 2, "CPU count (-smp)")
 	cmd.Flags().StringVar(&rcnf.Mem, "mem", "4G", "RAM size (-m)")
 	cmd.Flags().StringVar(&rcnf.CPUKind, "cpu-kind", "kvm64", "CPU kind to use (-cpu), has no effect when KVM is disabled")
+	cmd.Flags().IntVar(&rcnf.QemuMonitorPort, "qemu-monitor-port", 0, "Port for QEMU monitor")
 
 	return cmd
 }


### PR DESCRIPTION
Add an option to enable TCP-based QEMU monitor port. With this port, we can easily operate on the QEMU system. For example, we can kill VM process by `echo q | nc localhost <monitor port>`. Currently, this is the only usecase, but we can use any command listed here.

https://qemu-project.gitlab.io/qemu/system/monitor.html

Signed-off-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>