### PR TITLE
GHA: adapt to the new img tagging format

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
   image-version:
     description: 'LVH image version'
     required: true
-    default: '5.10'
+    default: '5.10-main'
   lvh-version:
     description: 'LVH cli version (Docker tag)'
     required: true
@@ -45,6 +45,7 @@ runs:
         if [ -f "/bin/lvh" ]; then
           echo '::set-output name=skip::true'
         fi
+
     - name: Install LVH cli
       if: ${{ inputs.provision == 'true' && steps.find-lvh-cli.outputs.skip != 'true' }}
       shell: bash
@@ -52,24 +53,33 @@ runs:
         cid=$(docker create quay.io/lvh-images/lvh:${{ inputs.lvh-version }})
         docker cp $cid:/usr/bin/lvh /bin/lvh
         docker rm $cid
+
     - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
       if: ${{ inputs.provision == 'true' }}
       id: cache-lvh-image
       with:
         path: /_images/${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst
         key: lvh-image-${{ inputs.image }}_${{ inputs.image-version }}
+
+    - name: Derive VM image file name
+      if: ${{ inputs.provision == 'true' }}
+      id: derive-image-name
+      shell: bash
+      run: echo "image-name=${{ inputs.image }}_$(echo ${{ inputs.image-version }} | sed 's/\(.*\)\-\(.*\)/\1/g')" >> $GITHUB_OUTPUT
+
     - name: Fetch VM image
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         mkdir /_images
-        docker run -v /_images:/mnt/images quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} cp /data/images/${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst /mnt/images
+        docker run -v /_images:/mnt/images quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} cp /data/images/${{ steps.derive-image-name.outputs.image-name }}.qcow2.zst /mnt/images
+
     - name: Prepare VM image
       if: ${{ inputs.provision == 'true'  }}
       shell: bash
       run: |
         cd /_images
-        zstd -d ${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst -o ${{ inputs.test-name }}.qcow2
+        zstd -d ${{ steps.derive-image-name.outputs.image-name }}.qcow2.zst -o ${{ inputs.test-name }}.qcow2
 
     - name: Start VM
       if: ${{ inputs.provision == 'true' }}


### PR DESCRIPTION
Previously, it used to be `kind:5.10`. Now, it's `kind:5.10-main`. The image file name didn't change though.

The CI has passed with the suggested changes (+ 4.19) - https://github.com/cilium/cilium/actions/runs/3416955761/jobs/5687625286.