### PR TITLE
action: Optionally set DNS resolver

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,9 @@ inputs:
     description: 'Provision VM (if set to false, only given test cmd is going to be run)'
     required: true
     default: 'true'
+  dns-resolver:
+    description: 'Set DNS resolver in /etc/resolv.conf of a VM'
+    required: false
   serial-port:
     description: 'Serial port to access VM'
     required: true
@@ -97,13 +100,20 @@ runs:
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \
             --cpu=${{ inputs.cpu }} --mem=${{ inputs.mem }}
 
+    - name: Set DNS resolver
+      if: ${{ inputs.provision == 'true' && inputs.dns-resolver != '' }}
+      shell: bash
+      run: |
+         ssh -p ${{ inputs.ssh-port }} -o "StrictHostKeyChecking=no" root@localhost << EOF
+         set -e
+         echo "nameserver ${{ inputs.dns-resolver }}" > /etc/resolv.conf
+         EOF
+
     - name: Run test cmd in VM
       shell: bash
       run: |
          ssh -p ${{ inputs.ssh-port }} -o "StrictHostKeyChecking=no" root@localhost << EOF
          set -eu
-
-         echo 'nameserver 1.1.1.1' > /etc/resolv.conf
 
          ${{ inputs.cmd }}
          EOF


### PR DESCRIPTION
The LVH VM images are built on Azure, and their /etc/resolv.conf point to an Azure DNS resolvers. The DNS resolution works fine if running on GHA runners (=Azure VMs).

However, this falls short once running on GKE, which we do via the poor man's ephemeral GH action runners.

Fix this by allowing users to specify dns-resolver addr to be used in the VMs.

Signed-off-by: Martynas Pumputis <m@lambda.lt>