### PR TITLE
action: support selection of cpu-kind

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,10 @@ inputs:
     description: 'RAM size'
     required: true
     default: '6G'
+  cpu-kind:
+    description: 'CPU kind to use'
+    required: true
+    default: 'host'
 runs:
   using: "composite"
   steps:
@@ -111,7 +115,7 @@ runs:
       run: |
         sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /_images/${{ inputs.test-name }}.qcow2 \
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \
-            --cpu=${{ inputs.cpu }} --mem=${{ inputs.mem }}
+            --cpu=${{ inputs.cpu }} --mem=${{ inputs.mem }} --cpu-kind ${{ inputs.cpu-kind }}
 
     - name: Set DNS resolver
       if: ${{ inputs.provision == 'true' && inputs.dns-resolver != '' }}


### PR DESCRIPTION
Support selection of CPU kind and default to host CPU. Depends on #27 so that should be merged first. The base of the PR should change automatically when that happens.