### PR TITLE
make: add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ little-vm-helper: FORCE
 image:
 	$(DOCKER) build -f Dockerfile -t $(OCIREPO) .
 
+.PHONY: install
+install:
+	CGO_ENABLED=0 $(GO) install ./cmd/lvh
+
 clean:
 	rm -f lvh
 FORCE:


### PR DESCRIPTION
Use `go install` to install the `lvh` binary to `$GOBIN` (`$HOME/go/bin` by default).