### PR TITLE
runner: move port-forwarding code under pkg/

### DIFF
--- a/cmd/lvh/runner/conf.go
+++ b/cmd/lvh/runner/conf.go
@@ -4,6 +4,7 @@
 package runner
 
 import (
+	"github.com/cilium/little-vm-helper/pkg/runner"
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,7 +22,7 @@ type RunConf struct {
 
 	// Disable the network connection to the VM
 	DisableNetwork bool
-	ForwardedPorts []PortForward
+	ForwardedPorts runner.PortForwards
 
 	Logger *logrus.Logger
 
@@ -39,10 +40,4 @@ type RunConf struct {
 
 func (rc *RunConf) testImageFname() string {
 	return rc.Image
-}
-
-type PortForward struct {
-	HostPort int
-	VMPort   int
-	Protocol string
 }

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -57,15 +57,7 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 	}
 
 	if !rcnf.DisableNetwork {
-		netdev := "user,id=user.0"
-		for _, fwd := range rcnf.ForwardedPorts {
-			netdev = fmt.Sprintf("%s,hostfwd=%s::%d-:%d", netdev, fwd.Protocol, fwd.HostPort, fwd.VMPort)
-		}
-
-		qemuArgs = append(qemuArgs,
-			"-netdev", netdev,
-			"-device", "virtio-net-pci,netdev=user.0",
-		)
+		qemuArgs = append(qemuArgs, rcnf.ForwardedPorts.QemuArgs()...)
 	}
 
 	if !rcnf.Daemonize {

--- a/pkg/runner/portforward.go
+++ b/pkg/runner/portforward.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runner
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type PortForward struct {
+	HostPort int
+	VMPort   int
+	Protocol string
+}
+
+type PortForwards []PortForward
+
+func ParsePortForward(flags []string) (PortForwards, error) {
+	var forwards []PortForward
+	for _, flag := range flags {
+		hostPortStr, vmPortAndProto, found := strings.Cut(flag, ":")
+		if !found {
+			hostPort, err := strconv.Atoi(flag)
+			if err != nil {
+				return nil, fmt.Errorf("'%s' is not a valid port number", flag)
+			}
+			forwards = append(forwards, PortForward{
+				HostPort: hostPort,
+				VMPort:   hostPort,
+				Protocol: "tcp",
+			})
+			continue
+		}
+
+		hostPort, err := strconv.Atoi(hostPortStr)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' is not a valid port number", hostPortStr)
+		}
+
+		vmPortStr, proto, found := strings.Cut(vmPortAndProto, ":")
+		if !found {
+			vmPort, err := strconv.Atoi(vmPortAndProto)
+			if err != nil {
+				return nil, fmt.Errorf("'%s' is not a valid port number", vmPortAndProto)
+			}
+			forwards = append(forwards, PortForward{
+				HostPort: hostPort,
+				VMPort:   vmPort,
+				Protocol: "tcp",
+			})
+			continue
+		}
+
+		vmPort, err := strconv.Atoi(vmPortStr)
+		if err != nil {
+			return nil, fmt.Errorf("'%s' is not a valid port number", vmPortStr)
+		}
+
+		proto = strings.ToLower(proto)
+		if proto != "tcp" && proto != "udp" {
+			return nil, fmt.Errorf("port forward protocol must be tcp or udp")
+		}
+
+		forwards = append(forwards, PortForward{
+			HostPort: hostPort,
+			VMPort:   vmPort,
+			Protocol: proto,
+		})
+	}
+
+	return forwards, nil
+}
+
+func (pf PortForwards) QemuArgs() []string {
+	netdev := "user,id=user.0"
+	for _, fwd := range pf {
+		netdev = fmt.Sprintf("%s,hostfwd=%s::%d-:%d", netdev, fwd.Protocol, fwd.HostPort, fwd.VMPort)
+	}
+	return []string{
+		"-netdev", netdev,
+		"-device", "virtio-net-pci,netdev=user.0",
+	}
+}


### PR DESCRIPTION
Move the port-forwarding code from cmd/lvh in pkg/runner. This allows using this code from other places (namely, the tetragon tester which is where most of the runner code comes from). We should do this for other parts of the runner so that cmd/lvh and tetragon tester can share the same code.