### PR TITLE
action: fix kernel argument

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -117,7 +117,7 @@ runs:
       shell: bash
       run: |
         extraArgs=()
-        if [ -z "${{ inputs.kernel }}" ]; then
+        if [ ! -z "${{ inputs.kernel }}" ]; then
           extraArgs+=("--kernel" "${{ inputs.kernel }}")
         fi
         sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /_images/${{ inputs.test-name }}.qcow2 \


### PR DESCRIPTION
We want to pass --kernel if $inputs.kernel is defined but we were accidentally checking for the opposite. This would cause the action to fail if kernel was undefined and not use the --kernel flag if it was.