### PR TITLE
action.yaml: Add retry when fetching dependencies

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -81,8 +81,16 @@ runs:
       if: ${{ inputs.provision == 'true' && inputs.install-dependencies == 'true' }}
       shell: bash
       run: |
-        sudo apt update
-        sudo apt install -y cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager
+        n=0
+        until [ "$n" -ge 5 ]; do
+          success=1
+          sudo apt update && \
+          sudo apt install -y cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager && \
+          break || success=0
+          n=$((n+1)) 
+          sleep 1
+        done
+        [ $success -eq 1 ] || exit 42
         sudo kvm-ok
 
     - uses: actions/cache@940f3d7cf195ba83374c77632d1e2cbb2f24ae68


### PR DESCRIPTION
Unfortunately, Github declined a proposal to pre-install qemu and friends into GHA runners \[1\]. So, let's try a poor man's solution instead.

\[1\]: https://github.com/actions/runner-images/issues/7541

Related https://github.com/cilium/cilium/issues/25483

Trying it out https://github.com/cilium/cilium/actions/runs/5001442860/jobs/8960138732.