### PR TITLE
runner: add a verbose flag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,10 @@ inputs:
   kernel:
     description: 'Path to kernel image to boot with'
     required: false
+  verbose:
+    description: 'Run in verbose mode'
+    required: true
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -127,6 +131,9 @@ runs:
         extraArgs=()
         if [ ! -z "${{ inputs.kernel }}" ]; then
           extraArgs+=("--kernel" "${{ inputs.kernel }}")
+        fi
+        if [ "${{ inputs.verbose == 'true' }}" ]; then
+          extraArgs+=("--verbose")
         fi
         sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /_images/${{ inputs.test-name }}.qcow2 \
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \

--- a/cmd/lvh/runner/conf.go
+++ b/cmd/lvh/runner/conf.go
@@ -20,6 +20,9 @@ type RunConf struct {
 	// Daemonize QEMU after initializing
 	Daemonize bool
 
+	// Print qemu command before running it
+	Verbose bool
+
 	// Disable the network connection to the VM
 	DisableNetwork bool
 	ForwardedPorts runner.PortForwards

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -62,6 +62,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().StringVar(&rcnf.Mem, "mem", "4G", "RAM size (-m)")
 	cmd.Flags().StringVar(&rcnf.CPUKind, "cpu-kind", "kvm64", "CPU kind to use (-cpu), has no effect when KVM is disabled")
 	cmd.Flags().IntVar(&rcnf.QemuMonitorPort, "qemu-monitor-port", 0, "Port for QEMU monitor")
+	cmd.Flags().BoolVarP(&rcnf.Verbose, "verbose", "v", false, "Print qemu command before running it")
 
 	return cmd
 }
@@ -74,7 +75,7 @@ func StartQemu(rcnf RunConf) error {
 		return err
 	}
 
-	if rcnf.QemuPrint {
+	if rcnf.QemuPrint || rcnf.Verbose {
 		var sb strings.Builder
 		sb.WriteString(qemuBin)
 		for _, arg := range qemuArgs {
@@ -86,7 +87,10 @@ func StartQemu(rcnf RunConf) error {
 		}
 
 		fmt.Printf("%s\n", sb.String())
-		return nil
+		// We don't want to return early if running in verbose mode
+		if rcnf.QemuPrint {
+			return nil
+		}
 	}
 
 	qemuPath, err := exec.LookPath(qemuBin)


### PR DESCRIPTION
Sometimes it is useful to print the qemu command but still run it afterwards. The existing --qemu-print-cmd flag suppresses the qemu command after printing, so let's add a new --verbose flag that does the same thing but without the suppression.