### PR TITLE
action: Bump LVH default version to v0.0.6

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
   lvh-version:
     description: 'LVH cli version (Docker tag)'
     required: true
-    default: 'v0.0.3'
+    default: 'v0.0.6'
   cmd:
     description: 'Commands to run in a VM'
     required: true


### PR DESCRIPTION
We're still hitting [failures](https://github.com/cilium/cilium/actions/runs/5308852252/jobs/9608811629) in cilium/cilium due to "LVH VM Provisioning" because we're still using the default version of `0.0.3` (that doesn't include the SSH fix https://github.com/cilium/little-vm-helper/pull/75 and released in `v0.0.6`).