### PR TITLE
Add watch on sshd status in "Wait for VM's SSH Server" step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -164,14 +164,29 @@ runs:
         if [ "${{ inputs.verbose }}" == "true" ]; then
           extraArgs+=("--verbose")
         fi
+        touch /tmp/console.log
         sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /_images/${{ inputs.test-name }}.qcow2 \
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \
             --cpu=${{ inputs.cpu }} --mem=${{ inputs.mem }} --cpu-kind ${{ inputs.cpu-kind }} \
+            --console-log-file /tmp/console.log \
             ${extraArgs[@]}
 
     - name: Wait for VM's SSH Server
       shell: bash
       run: |
+        n=0
+        until [ "$n" -ge 30 ]; do
+          started=1
+          if grep -E ".*OK.*Started.*ssh.*" /tmp/console.log; then
+            break || started=0
+          elif grep -E ".*FAILED.*Failed.*to.*start.*ssh*" /tmp/console.log; then
+            cat /tmp/console.log && exit 40
+          fi
+          n=$((n+1))
+          sleep 1
+        done
+        [ $started -eq 1 ] || (cat /tmp/console.log && exit 41)
+
         n=0
         until [ "$n" -ge 5 ]; do
           success=1
@@ -180,7 +195,7 @@ runs:
           n=$((n+1))
           sleep 1
         done
-        [ $success -eq 1 ] || exit 42
+        [ $success -eq 1 ] || (cat /tmp/console.log && exit 42)
 
     - name: Set DNS resolver
       if: ${{ inputs.provision == 'true' && inputs.dns-resolver != '' }}

--- a/cmd/lvh/runner/conf.go
+++ b/cmd/lvh/runner/conf.go
@@ -19,6 +19,8 @@ type RunConf struct {
 	DisableKVM bool
 	// Daemonize QEMU after initializing
 	Daemonize bool
+	// Log file for virtual console output
+	ConsoleLogFile string
 
 	// Print qemu command before running it
 	Verbose bool

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -39,6 +39,12 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 			fmt.Sprintf("telnet:localhost:%d,server,nowait", rcnf.SerialPort))
 	}
 
+	if rcnf.ConsoleLogFile != "" {
+		qemuArgs = append(qemuArgs,
+			"-serial",
+			fmt.Sprintf("file:%s", rcnf.ConsoleLogFile))
+	}
+
 	qemuArgs = append(qemuArgs,
 		"-hda", rcnf.testImageFname(),
 	)

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -55,6 +55,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&rcnf.QemuPrint, "qemu-cmd-print", false, "Do not run the qemu command, just print it")
 	cmd.Flags().BoolVar(&rcnf.DisableKVM, "qemu-disable-kvm", false, "Do not use KVM acceleration, even if /dev/kvm exists")
 	cmd.Flags().BoolVar(&rcnf.Daemonize, "daemonize", false, "daemonize QEMU after initializing")
+	cmd.Flags().StringVar(&rcnf.ConsoleLogFile, "console-log-file", "", "Save VM console output to given file")
 	cmd.Flags().StringVar(&rcnf.HostMount, "host-mount", "", "Mount the specified host directory in the VM using a 'host_mount' tag")
 	cmd.Flags().StringArrayVarP(&ports, "port", "p", nil, "Forward a port (hostport[:vmport[:tcp|udp]])")
 	cmd.Flags().IntVar(&rcnf.SerialPort, "serial-port", 0, "Port for serial console")


### PR DESCRIPTION
These two commits allow for adding a watch on sshd's status during the "Wait for VM's SSH Server" step, in an attempt to help resolve the flakes reported in https://github.com/cilium/cilium/issues/26012. By adding the ability to check on sshd's status in the VM, more information can be gained in regards to what could be happening in these flakes. Additionally, searching for specific status strings in the console log file is an inexpensive way to wait for the sshd server to startup.

To test this, I created two VMs: one with just an ssh server that will successfully start, and one with an ssh server that will fail to start.

The logs for the successful VM show the following:

```
[  OK  ] Reached target network.target - Network.
         Starting ssh.service - OpenBSD Secure Shell server...
         Starting systemd-user-sess…vice - Permit User Sessions...
[  OK  ] Finished systemd-user-sess…ervice - Permit User Sessions.
[  OK  ] Started getty@tty1.service - Getty on tty1.
[  OK  ] Started getty@tty2.service - Getty on tty2.
[  OK  ] Started getty@tty3.service - Getty on tty3.
[  OK  ] Started getty@tty4.service - Getty on tty4.
[  OK  ] Started getty@tty5.service - Getty on tty5.
[  OK  ] Started getty@tty6.service - Getty on tty6.
[  OK  ] Started serial-getty@ttyS0…rvice - Serial Getty on ttyS0.
[  OK  ] Reached target getty.target - Login Prompts.
[    2.161057] IPv6: ADDRCONF(NETDEV_CHANGE): ens2: link becomes ready
[    2.293043] random: crng init done
[  OK  ] Finished systemd-random-se…ce - Load/Save OS Random Seed.
[  OK  ] Started ssh.service - OpenBSD Secure Shell server.
[  OK  ] Reached target multi-user.target - Multi-User System.
[  OK  ] Reached target graphical.target - Graphical Interface.
         Starting systemd-update-ut… Record Runlevel Change in UTMP...
[  OK  ] Finished systemd-update-ut… - Record Runlevel Change in UTMP.

Debian GNU/Linux trixie/sid b0e82f92c653 ttyS0

b0e82f92c653 login:
```

While the logs for the failing VM show:

```
[  OK  ] Reached target network.target - Network.
         Starting ssh.service - OpenBSD Secure Shell server...
         Starting systemd-user-sess…vice - Permit User Sessions...
[  OK  ] Finished e2scrub_reap.serv…ine ext4 Metadata Check Snapshots.
[  OK  ] Finished systemd-user-sess…ervice - Permit User Sessions.
[  OK  ] Started getty@tty1.service - Getty on tty1.
[  OK  ] Started getty@tty2.service - Getty on tty2.
[  OK  ] Started getty@tty3.service - Getty on tty3.
[  OK  ] Started getty@tty4.service - Getty on tty4.
[  OK  ] Started getty@tty5.service - Getty on tty5.
[  OK  ] Started getty@tty6.service - Getty on tty6.
[  OK  ] Started serial-getty@ttyS0…rvice - Serial Getty on ttyS0.
[  OK  ] Reached target getty.target - Login Prompts.
[    2.127693] IPv6: ADDRCONF(NETDEV_CHANGE): ens2: link becomes ready
[    2.247729] random: crng init done
[FAILED] Failed to start ssh.servic…[0m - OpenBSD Secure Shell server.
See 'systemctl status ssh.service' for details.
[  OK  ] Reached target multi-user.target - Multi-User System.
[  OK  ] Reached target graphical.target - Graphical Interface.
         Starting systemd-update-ut… Record Runlevel Change in UTMP...
[  OK  ] Finished systemd-random-se…ce - Load/Save OS Random Seed.
[  OK  ] Finished systemd-update-ut… - Record Runlevel Change in UTMP.

Debian GNU/Linux trixie/sid 1210fc6805aa ttyS0

1210fc6805aa login:
```

The whitespace in these lines can sometimes be filled with terminal color codes, which is why the search strings in the action use `.*` in place of whitespace characters.