### PR TITLE
action: fix ssh console log file permissions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -164,7 +164,7 @@ runs:
         if [ "${{ inputs.verbose }}" == "true" ]; then
           extraArgs+=("--verbose")
         fi
-        touch /tmp/console.log
+        sudo touch /tmp/console.log
         sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /_images/${{ inputs.test-name }}.qcow2 \
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \
             --cpu=${{ inputs.cpu }} --mem=${{ inputs.mem }} --cpu-kind ${{ inputs.cpu-kind }} \


### PR DESCRIPTION
Currently, the action fails when trying to write to the console log file.

`qemu-system-x86_64: -serial file:/tmp/console.log: Could not open '/tmp/console.log': Permission denied`

e.g. https://github.com/cilium/cilium/actions/runs/5573110938/jobs/10180030621?pr=26819

This PR fixes this by setting the user root as owner of the file.

FYI @learnitall 

Fixes: #89