### PR TITLE
action: Wait for SSH only when provisioning

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -172,6 +172,7 @@ runs:
             ${extraArgs[@]}
 
     - name: Wait for VM's SSH Server
+      if: ${{ inputs.provision == 'true' }}
       shell: bash
       run: |
         n=0


### PR DESCRIPTION
Once it's provisioned, we know that the SSH is working.