### PR TITLE
action: Fix usage of CI images

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -153,7 +153,7 @@ runs:
       if: ${{ inputs.provision == 'true' }}
       id: derive-image-name
       shell: bash
-      run: echo "image-name=${{ inputs.image }}_$(echo ${{ inputs.image-version }} | sed 's/\(.*\)\-\(.*\)/\1/g')" >> $GITHUB_OUTPUT
+      run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/\(.*\)\-\(.*\)/\1/g')" >> $GITHUB_OUTPUT
 
     - name: Fetch VM image
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
Currently, the CI LVH VM images usage is broken in the action. For example, "kind-ci:5.15-20230925.121928" cannot be used due to:

    cp: can't stat '/data/images/kind-ci_5.15.qcow2.zst': No such file or directory

This is because the actual image name doesn't contain "-ci". Fix this, by removing the "-ci" suffix from the image name derivation.