### PR TITLE
kernels: disable some more options

### DIFF
--- a/pkg/kernels/conf.go
+++ b/pkg/kernels/conf.go
@@ -62,8 +62,8 @@ var ConfigOptGroups = map[string][]ConfigOption{
 		// NB: is not disabled from the final config
 		// {"--disable", "CONFIG_CDROM"},
 		{"--disable", "CONFIG_ISO9669_FS"},
-		// wireless
 		{"--disable", "CONFIG_CFG80211"},
+		{"--disable", "CONFIG_WIRELESS"},
 		{"--disable", "CONFIG_RFKILL"},
 		{"--disable", "CONFIG_MACINTOSH_DRIVERS"},
 		{"--disable", "CONFIG_SOUND"},
@@ -72,6 +72,11 @@ var ConfigOptGroups = map[string][]ConfigOption{
 		{"--disable", "CONFIG_USB"},
 		{"--disable", "CONFIG_WLAN"},
 		{"--disable", "CONFIG_HID"},
+		{"--disable", "CONFIG_I2C"},
+		{"--disable", "CONFIG_PCMCIA"},
+		{"--disable", "CONFIG_MD"},
+		{"--disable", "CONFIG_DMADEVICES"},
+		{"--disable", "CONFIG_THERMAL"},
 	},
 	"bpf": []ConfigOption{
 		{"--enable", "CONFIG_BPF"},


### PR DESCRIPTION
Disable some kernel config options that are not needed in an lvh VM.