### PR TITLE
kernels: add a extra_make_args parameter

### DIFF
--- a/pkg/kernels/conf.go
+++ b/pkg/kernels/conf.go
@@ -23,6 +23,8 @@ type KernelConf struct {
 	URL string `json:"url"`
 	// config options
 	Opts []ConfigOption `json:"opts,omitempty"`
+	// Extra make args
+	ExtraMakeArgs []string `json:"extra_make_args,omitempty"`
 }
 
 type Conf struct {


### PR DESCRIPTION
This can be used for adding extra arguments to make, as it is used to build kernels.

For example:
```
{
    "name": "4.19",
    "url": "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git?depth=1#linux-4.19.y"
    "extra_make_args": [
	    "V=1",
	    "HOSTCC=gcc-10",
	    "CC=gcc-10"
    ]
}
```