### PR TITLE
run: attach hard disk using virtio interface

### DIFF
--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -46,12 +46,12 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 	}
 
 	qemuArgs = append(qemuArgs,
-		"-hda", rcnf.testImageFname(),
+		"-drive", fmt.Sprintf("file=%s,if=virtio,index=0,media=disk", rcnf.testImageFname()),
 	)
 
 	if rcnf.KernelFname != "" {
 		appendArgs := []string{
-			"root=/dev/sda",
+			"root=/dev/vda",
 			"console=ttyS0",
 			"earlyprintk=ttyS0",
 			"panic=-1",


### PR DESCRIPTION
We currently use the default interface (aka IDE) to attach the hard disk image to the VM. IDE support has bitrotted on RHEL8 kernels and can't be enabled. Attach using the newer and more appropriate virtio interface instead.