### PR TITLE
kernel/build: fix ncpu detection

### DIFF
--- a/pkg/kernels/dir.go
+++ b/pkg/kernels/dir.go
@@ -215,7 +215,6 @@ func (kd *KernelsDir) buildKernel(ctx context.Context, log *logrus.Logger, kc *K
 	}
 
 	ncpus := fmt.Sprintf("%d", runtime.NumCPU())
-	ncpus = "1"
 	if err := runAndLogMake(ctx, log, kc, "-C", srcDir, "-j", ncpus, "bzImage", "modules"); err != nil {
 		return fmt.Errorf("buiding bzImage && modules failed: %w", err)
 	}


### PR DESCRIPTION
Commit 06c67d1 broke ncpu detection by overriding the value with 1 always. This makes it impossible to build kernels quickly without manually overriding make args for each kernel in kernels.json, which is not ideal in my opinion. Moreover, this looks like a change that was inadvertently introduced during testing given that the line which properly initializes ncpus was left in immediately above. Revert to the old behaviour.