### PR TITLE
action: fix incorrect -d flag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -162,7 +162,7 @@ runs:
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        /bin/lvh images pull --cache quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} -d "/"
+        /bin/lvh images pull --cache quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} --dir "/"
 
     - name: Start VM
       if: ${{ inputs.provision == 'true' }}


### PR DESCRIPTION
lvh images pull doesn't understand -d. The correct flag is --dir.