### PR TITLE
use virtio to attach root device after all

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -76,9 +76,6 @@ inputs:
   port-forward:
     description: 'Additional to SSH port forward ($LOCAL:$VM_PORT)'
     required: false
-  root-dev:
-    description: 'Root device (hda or vda)'
-    default: 'hda'
 runs:
   using: "composite"
   steps:
@@ -183,7 +180,6 @@ runs:
         sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /images/${{ inputs.test-name }}.qcow2 \
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \
             --cpu=${{ inputs.cpu }} --mem=${{ inputs.mem }} --cpu-kind ${{ inputs.cpu-kind }} \
-            --root-dev={{ inputs.root-dev }} \
             --console-log-file /tmp/console.log \
             ${extraArgs[@]}
 

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -94,7 +94,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().StringVar(&rcnf.Mem, "mem", "4G", "RAM size (-m)")
 	cmd.Flags().StringVar(&rcnf.CPUKind, "cpu-kind", "kvm64", "CPU kind to use (-cpu), has no effect when KVM is disabled")
 	cmd.Flags().IntVar(&rcnf.QemuMonitorPort, "qemu-monitor-port", 0, "Port for QEMU monitor")
-	cmd.Flags().StringVar(&rcnf.RootDev, "root-dev", "hda", "type of root device (hda or vda)")
+	cmd.Flags().StringVar(&rcnf.RootDev, "root-dev", "vda", "type of root device (hda or vda)")
 	cmd.Flags().BoolVarP(&rcnf.Verbose, "verbose", "v", false, "Print qemu command before running it")
 
 	return cmd

--- a/pkg/images/step_create_image.go
+++ b/pkg/images/step_create_image.go
@@ -21,7 +21,7 @@ var (
 	// DelImageIfExists: if set to true, image will be deleted at Cleanup() by the CreateImage step
 	DelImageIfExists = "DelImageIfExist"
 
-	rootDev    = "/dev/sda"
+	rootDev    = "/dev/vda"
 	rootFsType = "ext4"
 	resizeFS   = "resize2fs"
 )
@@ -104,7 +104,7 @@ func (s *CreateImage) makeRootImage(ctx context.Context) error {
 		imgSize = size
 	}
 
-	// example: guestfish -N foo.img=disk:8G -- mkfs ext4 /dev/sda : mount /dev/sda / : tar-in /tmp/foo.tar /
+	// example: guestfish -N foo.img=disk:8G -- mkfs ext4 /dev/vda : mount /dev/vda / : tar-in /tmp/foo.tar /
 	if s.bootable {
 		dirname, err := os.MkdirTemp("", "extlinux-")
 		if err != nil {


### PR DESCRIPTION
Revert "action: add root-dev input"

    This reverts commit 0819d3228d30cd65b0c5c0408bfb4dd293fee2ff.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

images: use /dev/vda as root device

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

lvh: make vda the default root device

    RHEL8 kernels only boot using virtio. The other kernels we build support IDE
    and virtio. Make vda the default so that we don't need to add vda / hda
    support to the builder.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
