### PR TITLE
renovate: Disable patch release bumps in go.mod

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -80,6 +80,25 @@
         "docker.io/library/golang"
       ],
     },
+    {
+      // Avoid updating patch releases of golang in go.mod
+      "enabled": "false",
+      "matchFiles": [
+        "go.mod",
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      matchBaseBranches: [
+        "main"
+      ]
+    },
   ],
   "regexManagers": [
     {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cilium/little-vm-helper
 
 // Keep at .0 to avoid imposing upgrades on developers
-go 1.21.6
+go 1.21.0
 
 require (
 	github.com/docker/docker v25.0.1+incompatible


### PR DESCRIPTION
Bumping this version in go.mod forces all developers to keep 100% up to
date on their tooling, by breaking their IDEs and compilation workflow 
if they are even just one patch release out of date. Inhibiting
developers' ability to contribute by forcing them to deal with local
administration outside of their typical update cycle creates an
unnecessary extra barrier to contribution.

For declaring the minimum required Go version in go.mod, we should set
it to the .0 patch release for the current target Go language level.
Release builds should rely on a separate mechanism to pull the latest
dependency.

This commit stops renovate from bumping the patch version in go.mod.

Related: https://github.com/cilium/cilium/pull/28686
