### PR TITLE
Add native arm64 support and cross-compilation for kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ depend on the kernel, such as BPF. It is used in [cilium](https://github.com/cil
 meant, and should not be used for running production VMs. Fast booting and image building, as well
 as being storage efficient are the main goals.
 
-It uses [qemu](https://www.qemu.org/) and [libguestfs tools](https://libguestfs.org/).
+It uses [qemu](https://www.qemu.org/) and [libguestfs tools](https://libguestfs.org/). See [dependencies](#what-are-the-dependencies-of-lvh).
 
 Configurations for specific images used in the Cilium project can be found in:
 https://github.com/cilium/little-vm-helper-images.
@@ -171,6 +171,18 @@ That being said, if we need packer functionality we can create a packer plugin
 These tools also target production VMs with lifetime streching beyond a single
 use. As a result, they introduce overhead in booting time, provisioning time,
 and storage.
+
+### What are the dependencies of LVH?
+
+On debian distribution, here is a list of packages needed for LVH to work.
+
+| Action                         | Debian packages                                                                                                        |
+| --------                       | -------                                                                                                                |
+| Building images                | `qemu-kvm mmdebstrap debian-archive-keyring libguestfs-tools`                                                          |
+| Building the Linux kernel      | `libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf llvm` |
+| Cross-compile arm64 on x86\_64 | `gcc-aarch64-linux-gnu`                                                                                                |
+| Cross-compile x86\_64 on arm64 | `gcc-x86-64-linux-gnu`                                                                                                 |
+
 
 ### TODO
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ $ go run ./cmd/lvh kernels --dir _data add bpf-next git://git.kernel.org/pub/scm
 $ go run ./cmd/lvh kernels --dir _data build bpf-next
 ```
 
+Please note, to cross-build for a different architecture, you can use the
+`--arch=arm64` or `--arch=amd64` flag.
+
 The configuration file keeps the url for a kernel, together with its configuration options:
 ```jsonc
 $ jq . < _data/kernel.json
@@ -123,7 +126,8 @@ bpf-next/
 git/
 ```
 
-Currently, kernels are built using the `bzImage` and `dir-pkg` targets (see [pkg/kernels/conf.go](pkg/kernels/conf.go)).
+Currently, kernels are built using the `bzImage` for x86\_64 or `Image.gz` for
+arm64, and `tar-pkg` targets (see [pkg/kernels/conf.go](pkg/kernels/conf.go)).
 
 ### Booting images
 

--- a/cmd/lvh/kernels/build.go
+++ b/cmd/lvh/kernels/build.go
@@ -12,14 +12,20 @@ import (
 )
 
 func buildCommand() *cobra.Command {
-	return &cobra.Command{
+	var arch string
+
+	cmd := &cobra.Command{
 		Use:   "build <kernel>",
 		Short: "build kernel",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := logrus.New()
 			kname := args[0]
-			return kernels.BuildKernel(context.Background(), log, dirName, kname, false /* TODO: add fetch flag */)
+			return kernels.BuildKernel(context.Background(), log, dirName, kname, false /* TODO: add fetch flag */, arch)
 		},
 	}
+
+	cmd.Flags().StringVar(&arch, "arch", "", "target architecture to build the kernel, e.g. 'amd64' or 'arm64' (default to native architecture)")
+
+	return cmd
 }

--- a/cmd/lvh/kernels/configure.go
+++ b/cmd/lvh/kernels/configure.go
@@ -12,7 +12,9 @@ import (
 )
 
 func configureCommand() *cobra.Command {
-	return &cobra.Command{
+	var arch string
+
+	cmd := &cobra.Command{
 		Use:   "configure <kernel>",
 		Short: "configure kernel",
 		Args:  cobra.ExactArgs(1),
@@ -24,12 +26,16 @@ func configureCommand() *cobra.Command {
 			}
 
 			kname := args[0]
-			if err := kd.ConfigureKernel(context.Background(), log, kname); err != nil {
+			if err := kd.ConfigureKernel(context.Background(), log, kname, arch); err != nil {
 				log.Fatal(err)
 			}
 
 		},
 	}
+
+	cmd.Flags().StringVar(&arch, "arch", "", "target architecture to configure the kernel, e.g. 'amd64' or 'arm64' (default to native architecture)")
+
+	return cmd
 }
 
 func rawConfigureCommand() *cobra.Command {

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cilium/little-vm-helper/pkg/arch"
 	"github.com/sirupsen/logrus"
 )
 
@@ -58,9 +59,14 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 	}
 
 	if rcnf.KernelFname != "" {
+		console, err := arch.Console()
+		if err != nil {
+			return nil, fmt.Errorf("failed retrieving console name: %w", err)
+		}
+
 		appendArgs := []string{
 			fmt.Sprintf("root=%s", kernelRoot),
-			"console=ttyS0",
+			fmt.Sprintf("console=%s", console),
 			"earlyprintk=ttyS0",
 			"panic=-1",
 		}

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -24,6 +24,8 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 		"-smp", fmt.Sprintf("%d", rcnf.CPU), "-m", rcnf.Mem,
 	}
 
+	qemuArgs = arch.AppendArchSpecificQemuArgs(qemuArgs)
+
 	// quick-and-dirty kvm detection
 	if !rcnf.DisableKVM {
 		if f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0755); err == nil {

--- a/cmd/lvh/runner/qemu.go
+++ b/cmd/lvh/runner/qemu.go
@@ -27,14 +27,18 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 	qemuArgs = arch.AppendArchSpecificQemuArgs(qemuArgs)
 
 	// quick-and-dirty kvm detection
+	kvmEnabled := false
 	if !rcnf.DisableKVM {
 		if f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0755); err == nil {
-			qemuArgs = append(qemuArgs, "-enable-kvm", "-cpu", rcnf.CPUKind)
+			qemuArgs = append(qemuArgs, "-enable-kvm")
 			f.Close()
+			kvmEnabled = true
 		} else {
 			log.Info("KVM disabled")
 		}
 	}
+
+	qemuArgs = arch.AppendCPUKind(qemuArgs, kvmEnabled, rcnf.CPUKind)
 
 	if rcnf.SerialPort != 0 {
 		qemuArgs = append(qemuArgs,

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/little-vm-helper/pkg/arch"
 	"github.com/cilium/little-vm-helper/pkg/images"
 	"github.com/cilium/little-vm-helper/pkg/runner"
 	"github.com/sirupsen/logrus"
@@ -100,9 +101,12 @@ func RunCommand() *cobra.Command {
 	return cmd
 }
 
-const qemuBin = "qemu-system-x86_64"
-
 func StartQemu(rcnf RunConf) error {
+	qemuBin, err := arch.QemuBinary()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Qemu binary: %w", err)
+	}
+
 	qemuArgs, err := BuildQemuArgs(rcnf.Logger, &rcnf)
 	if err != nil {
 		return err

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -93,7 +93,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().IntVar(&rcnf.SerialPort, "serial-port", 0, "Port for serial console")
 	cmd.Flags().IntVar(&rcnf.CPU, "cpu", 2, "CPU count (-smp)")
 	cmd.Flags().StringVar(&rcnf.Mem, "mem", "4G", "RAM size (-m)")
-	cmd.Flags().StringVar(&rcnf.CPUKind, "cpu-kind", "kvm64", "CPU kind to use (-cpu), has no effect when KVM is disabled")
+	cmd.Flags().StringVar(&rcnf.CPUKind, "cpu-kind", "", "CPU kind to use (-cpu), has no effect when KVM is disabled (default 'kvm64' on amd64 and 'max' on arm64)")
 	cmd.Flags().IntVar(&rcnf.QemuMonitorPort, "qemu-monitor-port", 0, "Port for QEMU monitor")
 	cmd.Flags().StringVar(&rcnf.RootDev, "root-dev", "vda", "type of root device (hda or vda)")
 	cmd.Flags().BoolVarP(&rcnf.Verbose, "verbose", "v", false, "Print qemu command before running it")

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -42,3 +42,15 @@ func Console() (string, error) {
 		return "", ErrUnsupportedArch
 	}
 }
+
+// AppendArchSpecificQemuArgs appends Qemu arguments to the input that are
+// specific to the architecture lvh is running on. For example on ARM64, Qemu
+// needs some precision on the -machine option to start.
+func AppendArchSpecificQemuArgs(qemuArgs []string) []string {
+	switch runtime.GOARCH {
+	case "arm64":
+		return append(qemuArgs, "-machine", "virt", "-cpu", "max")
+	default:
+		return qemuArgs
+	}
+}

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -49,8 +49,26 @@ func Console() (string, error) {
 func AppendArchSpecificQemuArgs(qemuArgs []string) []string {
 	switch runtime.GOARCH {
 	case "arm64":
-		return append(qemuArgs, "-machine", "virt", "-cpu", "max")
+		return append(qemuArgs, "-machine", "virt")
 	default:
 		return qemuArgs
 	}
+}
+
+// AppendCPUKind appends the -cpu type if needed, historically amd64 has used no
+// specific kind when running without KVM, and using kvm64 when running with
+// KVM. However, arm64 needs -cpu max in both cases to start properly.
+func AppendCPUKind(qemuArgs []string, kvmEnabled bool, cpuKind string) []string {
+	if cpuKind != "" {
+		return append(qemuArgs, "-cpu", cpuKind)
+	}
+	switch runtime.GOARCH {
+	case "amd64":
+		if kvmEnabled {
+			return append(qemuArgs, "-cpu", "kvm64")
+		}
+	case "arm64":
+		return append(qemuArgs, "-cpu", "max")
+	}
+	return qemuArgs
 }

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 )
 
+var ErrUnsupportedArch = fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+
 // Target returns the Linux Makefile target to build the kernel, for historical
 // reasons, those are different between architectures.
 func Target() (string, error) {
@@ -14,6 +16,17 @@ func Target() (string, error) {
 	case "arm64":
 		return "Image.gz", nil
 	default:
-		return "", fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+		return "", ErrUnsupportedArch
+	}
+}
+
+func QemuBinary() (string, error) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "qemu-system-x86_64", nil
+	case "arm64":
+		return "qemu-system-aarch64", nil
+	default:
+		return "", ErrUnsupportedArch
 	}
 }

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -72,3 +72,14 @@ func AppendCPUKind(qemuArgs []string, kvmEnabled bool, cpuKind string) []string 
 	}
 	return qemuArgs
 }
+
+// Bootable returns the arch-dependent default value in case the pointer is nil,
+// so option is unconfigured. Typically arm64 should not be bootable by default
+// because we didn't take the time to find a bootloader that was arm64
+// compatible so far.
+func Bootable(bootable *bool) bool {
+	if bootable == nil {
+		return runtime.GOARCH == "amd64"
+	}
+	return *bootable
+}

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -1,0 +1,19 @@
+package arch
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Target returns the Linux Makefile target to build the kernel, for historical
+// reasons, those are different between architectures.
+func Target() (string, error) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "bzImage", nil
+	case "arm64":
+		return "Image.gz", nil
+	default:
+		return "", fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+	}
+}

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -30,3 +30,15 @@ func QemuBinary() (string, error) {
 		return "", ErrUnsupportedArch
 	}
 }
+
+// Console returns the name of the device for the first serial port.
+func Console() (string, error) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "ttyS0", nil
+	case "arm64":
+		return "ttyAMA0", nil
+	default:
+		return "", ErrUnsupportedArch
+	}
+}

--- a/pkg/images/conf.go
+++ b/pkg/images/conf.go
@@ -11,6 +11,9 @@ type ImgConf struct {
 	Parent string `json:"parent,omitempty"`
 	// ImageSize is the size of the image (defaults to images.DefaultImageSize)
 	ImageSize string `json:"image_size,omitempty"`
+	// Bootable indicates if the image should be bootable, i.e. contain a kernel
+	// and a bootloader.
+	Bootable *bool `json:"bootable,omitempty"`
 	// Packages is the list of packages contained in the image
 	Packages []string `json:"packages"`
 	// Actions is a list of additional actions for building the image.

--- a/pkg/images/step_create_image.go
+++ b/pkg/images/step_create_image.go
@@ -5,6 +5,7 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -74,6 +75,9 @@ append initrd=initrd.img root=%s rw console=ttyS0
 
 // makeRootImage creates a root (with respect to the image forest hierarch) image
 func (s *CreateImage) makeRootImage(ctx context.Context) error {
+	if s == nil || s.imgCnf == nil {
+		return errors.New("step configuration or image configuration is nil")
+	}
 	imgFname := filepath.Join(s.imagesDir, s.imgCnf.Name)
 	tarFname := path.Join(s.imagesDir, fmt.Sprintf("%s.tar", s.imgCnf.Name))
 	// build package list: add a kernel if building a bootable image

--- a/pkg/images/step_create_image.go
+++ b/pkg/images/step_create_image.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cilium/little-vm-helper/pkg/arch"
 	"github.com/cilium/little-vm-helper/pkg/logcmd"
 	"github.com/cilium/little-vm-helper/pkg/step"
 	"github.com/sirupsen/logrus"
@@ -74,8 +75,7 @@ func (s *CreateImage) makeRootImage(ctx context.Context) error {
 	}
 	imgFname := filepath.Join(s.imagesDir, s.imgCnf.Name)
 	tarFname := path.Join(s.imagesDir, fmt.Sprintf("%s.tar", s.imgCnf.Name))
-	// if bootable is unset, bootable defaults to true, otherwise value tells
-	bootable := s.imgCnf.Bootable == nil || *s.imgCnf.Bootable
+	bootable := arch.Bootable(s.imgCnf.Bootable)
 	// build package list: add a kernel if building a bootable image
 	packages := make([]string, 0, len(s.imgCnf.Packages)+1)
 	if bootable {

--- a/pkg/kernels/dir.go
+++ b/pkg/kernels/dir.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 
+	"github.com/cilium/little-vm-helper/pkg/arch"
 	"github.com/cilium/little-vm-helper/pkg/logcmd"
 	"github.com/sirupsen/logrus"
 )
@@ -230,7 +231,12 @@ func (kd *KernelsDir) buildKernel(ctx context.Context, log *logrus.Logger, kc *K
 	}
 
 	ncpus := fmt.Sprintf("%d", runtime.NumCPU())
-	if err := runAndLogMake(ctx, log, kc, "-C", srcDir, "-j", ncpus, "bzImage", "modules"); err != nil {
+
+	target, err := arch.Target()
+	if err != nil {
+		return fmt.Errorf("failed to get make target: %w", err)
+	}
+	if err := runAndLogMake(ctx, log, kc, "-C", srcDir, "-j", ncpus, target, "modules"); err != nil {
 		return fmt.Errorf("buiding bzImage && modules failed: %w", err)
 	}
 

--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -163,7 +163,7 @@ func FetchKernel(ctx context.Context, log *logrus.Logger, dir, kname string) err
 	return kurl.fetch(ctx, log, kd.Dir, kc.Name)
 }
 
-func BuildKernel(ctx context.Context, log *logrus.Logger, dir, kname string, fetch bool) error {
+func BuildKernel(ctx context.Context, log *logrus.Logger, dir, kname string, fetch bool, arch string) error {
 	kd, kc, kurl, err := getKernelInfo(dir, kname)
 	if err != nil {
 		return err
@@ -176,5 +176,5 @@ func BuildKernel(ctx context.Context, log *logrus.Logger, dir, kname string, fet
 
 	}
 
-	return kd.buildKernel(ctx, log, kc)
+	return kd.buildKernel(ctx, log, kc, arch)
 }


### PR DESCRIPTION
Fixes #56.

With this update, you can:
- Build kernel natively on both amd64 and arm64.
- Build kernel with cross-compilation on amd64 and arm64 to respectively arm64 and amd64.
- Build image natively on amd64 and arm64.
- Run the kernel with the image natively on amd64 and arm64.

You _cannot_ build an arm64 image on amd64 because of libguestfs tools limitations, unfortunately, `mmdebstrap` works perfectly fine with emulation but libguestfs tools rely on Qemu to start the VMs to modify the images and it's not set up for emulation.

Also, this introduces a new `bootable` field in the image conf since with this patch. For now, we can only build non-bootable images for arm64 as I haven't taken the time to investigate the bootloader part that we could use (since extlinux used here is x86_64 only). So the default is that images are bootable by default on x86_64 and non-bootable by default on arm64. You can use the new field to be precise.

This might not be the ideal setup as I haven't taken the time to look into the kernel config specific for arm64 to we should change. It seems to work ok at least, maybe we are not very optimized but...