### PR TITLE
pkg/runner: move functions from cmd/lvh/runner to the pkg

### DIFF
--- a/pkg/runner/conf.go
+++ b/pkg/runner/conf.go
@@ -12,6 +12,8 @@ type RunConf struct {
 	Image string
 	// kernel filename to boot with. (if empty no -kernel option will be passed to qemu)
 	KernelFname string
+	// kernel append args to add when a kernel is passed to qemu
+	KernelAppendArgs []string
 	// Do not run the qemu command, just print it
 	QemuPrint bool
 	// Do not use KVM acceleration, even if /dev/kvm exists

--- a/pkg/runner/conf.go
+++ b/pkg/runner/conf.go
@@ -4,7 +4,6 @@
 package runner
 
 import (
-	"github.com/cilium/little-vm-helper/pkg/runner"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,7 +26,7 @@ type RunConf struct {
 
 	// Disable the network connection to the VM
 	DisableNetwork bool
-	ForwardedPorts runner.PortForwards
+	ForwardedPorts PortForwards
 
 	Logger *logrus.Logger
 

--- a/pkg/runner/qemu.go
+++ b/pkg/runner/qemu.go
@@ -78,9 +78,10 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 			"earlyprintk=ttyS0",
 			"panic=-1",
 		}
+		appendArgs = append(appendArgs, rcnf.KernelAppendArgs...)
 		qemuArgs = append(qemuArgs,
 			"-kernel", rcnf.KernelFname,
-			"-append", fmt.Sprintf("%s", strings.Join(appendArgs, " ")),
+			"-append", strings.Join(appendArgs, " "),
 		)
 	}
 


### PR DESCRIPTION
This will be better to use those functions as library functions if they are located in pkg/runner.

See https://github.com/cilium/tetragon/pull/2333.