### PR TITLE
cmd/images: transform --image into a string array

### DIFF
--- a/cmd/lvh/images/build.go
+++ b/cmd/lvh/images/build.go
@@ -16,8 +16,9 @@ import (
 )
 
 func BuildCmd() *cobra.Command {
-	var dirName, imageName string
+	var dirName string
 	var forceRebuild, dryRun, mergeSteps bool
+	var imageNames []string
 
 	cmd := &cobra.Command{
 		Use:   "build",
@@ -55,14 +56,10 @@ func BuildCmd() *cobra.Command {
 				MergeSteps:   mergeSteps,
 			}
 			start := time.Now()
-			if imageName == "" {
+			if imageNames == nil {
 				res = forest.BuildAllImages(bldConf)
 			} else {
-				res, err = forest.BuildImage(bldConf, imageName)
-				if err != nil {
-					log.WithField("image", imageName).WithError(err).Error("error bulding image")
-					return err
-				}
+				res = forest.BuildImages(bldConf, imageNames)
 			}
 			elapsed := time.Since(start)
 
@@ -84,8 +81,8 @@ func BuildCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&dirName, "dir", "", "directory to keep the images (configuration will be saved in <dir>/images.json and images in <dir>/images)")
-	cmd.Flags().StringVar(&imageName, "image", "", "image to build. If empty, all images will be build.")
 	cmd.MarkFlagRequired("dir")
+	cmd.Flags().StringArrayVarP(&imageNames, "image", "i", nil, "images to build. If empty, all images will be built.")
 	cmd.Flags().BoolVar(&forceRebuild, "force-rebuild", false, "rebuild all images, even if they exist")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "do the whole thing, but instead of building actual images create empty files")
 	cmd.Flags().BoolVar(&mergeSteps, "merge-steps", true, "Merge steps when possible to improve performance. Disabling this might be useufl to investigate action issues.")

--- a/pkg/images/build.go
+++ b/pkg/images/build.go
@@ -77,13 +77,17 @@ func (f *ImageForest) BuildImage(bldConf *BuildConf, image string) (*BuilderResu
 // BuildAllImages will build all images in the forest. It will start from the
 // roots, and work its way down.
 func (f *ImageForest) BuildAllImages(bldConf *BuildConf) *BuilderResult {
+	return f.BuildImages(bldConf, f.RootImages())
+}
+
+// BuildImages will build the images specified in the queue from the forest. It
+// will start from the roots, and work its way down.
+func (f *ImageForest) BuildImages(bldConf *BuildConf, queue []string) *BuilderResult {
 	log := bldConf.Log
 	st := newBuildState(f, bldConf)
-
-	queue := f.RootImages()
 	log.WithFields(logrus.Fields{
 		"queue": strings.Join(queue, ","),
-	}).Info("starting to build all images")
+	}).Info("starting to build images")
 	for {
 		var image string
 		if len(queue) == 0 {


### PR DESCRIPTION
This will be useful to specify specific images to build in the images.json file.

I need this for to build both `kind.qcow2` and `base.qcow2` in the little-vm-helper images CI for the vmtests to work on Tetragon arm64.