### PR TITLE
action: add -p option mkdir images and fix cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: 'LVH image version'
     required: true
     default: '5.10-main'
+  images-folder-parent:
+    description: 'Parent folder in which to put the downloaded images'
+    required: false
+    default: ''
   lvh-version:
     description: 'LVH cli version (Docker tag)'
     required: true
@@ -151,9 +155,10 @@ runs:
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        sudo mkdir /images; sudo chmod 777 /images
-        /bin/lvh images pull --cache quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} --dir "/"
-        find /images
+        sudo mkdir -p ${{ inputs.images-folder-parent }}/images; sudo chmod 777 ${{ inputs.images-folder-parent }}/images
+        /bin/lvh images pull --cache quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} --dir "${{ inputs.images-folder-parent }}/"
+        find ${{ inputs.images-folder-parent }}/images -type f -exec sudo chmod 666 {} +
+        find ${{ inputs.images-folder-parent }}/images
     - name: Start VM
       if: ${{ inputs.provision == 'true' }}
       shell: bash
@@ -169,7 +174,7 @@ runs:
           extraArgs+=("-p" "${{ inputs.port-forward }}")
         fi
         sudo touch /tmp/console.log
-        sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /images/${{ steps.derive-image-name.outputs.image-name }}.qcow2 \
+        sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image ${{ inputs.images-folder-parent }}/images/${{ steps.derive-image-name.outputs.image-name }}.qcow2 \
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \
             --cpu=${{ inputs.cpu }} --mem=${{ inputs.mem }} --cpu-kind ${{ inputs.cpu-kind }} \
             --console-log-file /tmp/console.log \

--- a/action.yaml
+++ b/action.yaml
@@ -151,6 +151,10 @@ runs:
       with:
         path: ${{ inputs.images-folder-parent }}/images/${{ steps.derive-image-name.outputs.image-name }}.qcow2.zst
         key: lvh-image-${{ inputs.image }}_${{ inputs.image-version }}
+    - name: Decompressed cached VM image
+      if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit == 'true' }}
+      shell: bash
+      run: zstd -df ${{ inputs.images-folder-parent }}/images/${{ steps.derive-image-name.outputs.image-name }}.qcow2.zst
     - name: Fetch VM image
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -140,17 +140,17 @@ runs:
         sudo cp /tmp/.ubuntu-pkgs/*.deb /var/cache/apt/archives/
         sudo apt-get -y --no-install-recommends install /tmp/.ubuntu-pkgs/*.deb
         sudo kvm-ok
-    - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
-      if: ${{ inputs.provision == 'true' }}
-      id: cache-lvh-image
-      with:
-        path: /images/${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst
-        key: lvh-image-${{ inputs.image }}_${{ inputs.image-version }}
     - name: Derive VM image file name
       if: ${{ inputs.provision == 'true' }}
       id: derive-image-name
       shell: bash
       run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/\(.*\)\-\(.*\)/\1/g')" >> $GITHUB_OUTPUT
+    - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      if: ${{ inputs.provision == 'true' }}
+      id: cache-lvh-image
+      with:
+        path: ${{ inputs.images-folder-parent }}/images/${{ steps.derive-image-name.outputs.image-name }}.qcow2.zst
+        key: lvh-image-${{ inputs.image }}_${{ inputs.image-version }}
     - name: Fetch VM image
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash


### PR DESCRIPTION
This can cause the action to fail on a runner on which the /images folder already exists.

Quick and (slightly) dirty fix for my needs to run LVH on hosted arm64 bare metal runners.