### PR TITLE
gha: remove fragile SSH startup check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,18 +24,10 @@ inputs:
     description: 'SSH port for VM on a host'
     required: true
     default: 2222
-  ssh-startup-wait-retries:
-    description: 'Number of retries to wait for SSH server startup'
-    required: true
-    default: 300
-  ssh-startup-wait-timeout:
-    description: 'Timeout in seconds between retries to wait for SSH server startup'
-    required: true
-    default: 1
   ssh-connect-wait-retries:
     description: 'Number of retries to connect to the SSH server'
     required: true
-    default: 5
+    default: 300
   ssh-connect-wait-timeout:
     description: 'Timeout in seconds between retries to connect to the SSH server'
     required: true
@@ -194,24 +186,6 @@ runs:
       if: ${{ inputs.provision == 'true' }}
       shell: bash
       run: |
-        n=0
-        started=0
-        until [ "$n" -ge ${{ inputs.ssh-startup-wait-retries }} ]; do
-          if grep -E ".*OK.*Started.*ssh.*" /tmp/console.log; then
-            started=1
-            break
-          elif grep -E ".*FAILED.*Failed.*to.*start.*ssh*" /tmp/console.log; then
-            cat /tmp/console.log
-            exit 40
-          fi
-          n=$((n+1))
-          sleep ${{ inputs.ssh-startup-wait-timeout }}
-        done
-        if [ $started -eq 0 ]; then
-          cat /tmp/console.log
-          exit 41
-        fi
-
         n=0
         success=0
         until [ "$n" -ge ${{ inputs.ssh-connect-wait-retries }} ]; do


### PR DESCRIPTION
Currently, the LVH GH action verifies the successful start of the SSH server by searching the console logoutput for the corresponding log lines.

This mechanism is very fragile and leads to cases where a successful SSH server start isn't detected properly. E.g. in cases where the logoutput by qemu is interleaved.

```
[  OK  ] Started     4.887573] e2scrub_all (319) used greatest stack depth: 12416 bytes left
1;39mssh.service - OpenBSD Secure Shell server.
```

Therefore, this commit removes the SSH server startup check completely. Leaving the check for a successful SSH connect to be the only check.

To respect the SSH server startup time, the default wait retries for the SSH connection check gets increased from 5 to 300 (the time that we potentially waited for the SSH startup in the log check).

Fixes: https://github.com/cilium/cilium/issues/32400