### PR TITLE
renovate: enable automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,7 @@
     "renovate/stop-updating",
   ],
   "stopUpdatingLabel": "renovate/stop-updating",
+  "automerge": true,
   "packageRules": [
     {
       "groupName": "all github action dependencies",


### PR DESCRIPTION
This commit enables automerge for all renovate PRs.

https://docs.renovatebot.com/key-concepts/automerge/

Renovate will automatically merge the PRs if all all checks are successful.

Note: I have deliberately not distinguished between major/minor/... dependencies. IMO a failing check is indication enough that manual interaction is required.

@kkourt : in addition to this PR we have to allow renovate to bypass the branch protection rule. Only this way it's possible for renovate to merge PRs without any approvals. https://github.blog/changelog/2021-11-19-allow-bypassing-required-pull-requests/
