### PR TITLE
action: fix image derive step with multiple dashes

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -136,7 +136,7 @@ runs:
       if: ${{ inputs.provision == 'true' }}
       id: derive-image-name
       shell: bash
-      run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/\(.*\)\-\(.*\)/\1/g')" >> $GITHUB_OUTPUT
+      run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/\([^-]*\)\-\(.*\)/\1/g')" >> $GITHUB_OUTPUT
     - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       if: ${{ inputs.provision == 'true' }}
       id: cache-lvh-image


### PR DESCRIPTION
An image name that contains multiple dashes breaks because sed greedily matches on the initial `.*` pattern. To fix this, change the initial `.*` to `[^-]` so that it matches until we encounter the first dash character.