### PR TITLE
renovate: don't add stop-updating label

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,6 @@
   },
   "labels": [
     "dependencies",
-    "renovate/stop-updating",
   ],
   "stopUpdatingLabel": "renovate/stop-updating",
   "packageRules": [


### PR DESCRIPTION
Currently, it seems that the presence of the label `renovate/stop-updating` github label prevents renovate from automatically merging the PRs. It only ever worked when removing the label manually.

Therefore, this commit changes the renovate configuration to not add the label when opening a pull request.

Example: https://github.com/cilium/little-vm-helper/pull/245