### PR TITLE
updates to work with arm64 on x86

### DIFF
--- a/cmd/lvh/images/pull.go
+++ b/cmd/lvh/images/pull.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	dirName string
-	cache   bool
+	dirName  string
+	cache    bool
+	platform string
 )
 
 func PullCmd() *cobra.Command {
@@ -34,6 +35,7 @@ func PullCmd() *cobra.Command {
 				Image:     args[0],
 				TargetDir: dirName,
 				Cache:     cache,
+				Platform:  platform,
 			}
 			if err := images.PullImage(context.Background(), pcnf); err != nil {
 				return err
@@ -48,6 +50,7 @@ func PullCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&dirName, "dir", "_data", "directory to keep the images (images will be saved in images in <dir>/images)")
 	cmd.Flags().BoolVar(&cache, "cache", false, "cache a compressed version of the image")
+	cmd.Flags().StringVar(&platform, "platform", "", "platform")
 
 	return cmd
 }

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/cilium/little-vm-helper/pkg/images"
@@ -95,6 +96,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().IntVar(&rcnf.QemuMonitorPort, "qemu-monitor-port", 0, "Port for QEMU monitor")
 	cmd.Flags().StringVar(&rcnf.RootDev, "root-dev", "vda", "type of root device (hda or vda)")
 	cmd.Flags().BoolVarP(&rcnf.Verbose, "verbose", "v", false, "Print qemu command before running it")
+	cmd.Flags().StringVar(&rcnf.QemuArch, "qemu-arch", runtime.GOARCH, "specify qemu arch to use")
 
 	return cmd
 }

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -5,91 +5,102 @@ import (
 	"runtime"
 )
 
-var ErrUnsupportedArch = fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+type Arch string
+
+func NewArch(arch string) (Arch, error) {
+	switch arch {
+	case "amd64", "arm64":
+		return Arch(arch), nil
+	default:
+		return Arch(""), fmt.Errorf("unsupported architecture %s", arch)
+	}
+}
 
 // Target returns the Linux Makefile target to build the kernel, for historical
 // reasons, those are different between architectures.
-func Target(arch string) (string, error) {
-	if arch == "" {
-		arch = runtime.GOARCH
-	}
-	switch arch {
+func (a Arch) Target() string {
+	switch a {
 	case "amd64":
-		return "bzImage", nil
+		return "bzImage"
 	case "arm64":
-		return "Image.gz", nil
+		return "Image.gz"
 	default:
-		return "", fmt.Errorf("unsupported architecture for Makefile target: %s", arch)
+		panic(fmt.Sprintf("Target(): Unsupported arch: %s", a))
 	}
 }
 
-func CrossCompiling(targetArch string) bool {
-	return targetArch != "" && targetArch != runtime.GOARCH
+func (a Arch) CrossCompiling() bool {
+	return string(a) != runtime.GOARCH
 }
 
-func CrossCompileMakeArgs(targetArch string) ([]string, error) {
-	if !CrossCompiling(targetArch) {
-		return nil, nil
+func (a Arch) CrossCompileMakeArgs() []string {
+	if !a.CrossCompiling() {
+		return nil
 	}
 
-	switch targetArch {
+	switch a {
 	case "arm64":
-		return []string{"ARCH=arm64", "CROSS_COMPILE=aarch64-linux-gnu-"}, nil
+		return []string{"ARCH=arm64", "CROSS_COMPILE=aarch64-linux-gnu-"}
 	case "amd64":
-		return []string{"ARCH=x86_64", "CROSS_COMPILE=x86_64-linux-gnu-"}, nil
-	}
-	return nil, fmt.Errorf("unsupported architecture for cross-compilation: %s", targetArch)
-}
-
-func QemuBinary() (string, error) {
-	switch runtime.GOARCH {
-	case "amd64":
-		return "qemu-system-x86_64", nil
-	case "arm64":
-		return "qemu-system-aarch64", nil
+		return []string{"ARCH=x86_64", "CROSS_COMPILE=x86_64-linux-gnu-"}
 	default:
-		return "", ErrUnsupportedArch
+		panic(fmt.Sprintf("CrossCompileMakeArgs(): Unsupported arch: %s", a))
+	}
+}
+
+func (a Arch) QemuBinary() string {
+	switch a {
+	case "amd64":
+		return "qemu-system-x86_64"
+	case "arm64":
+		return "qemu-system-aarch64"
+	default:
+		panic(fmt.Sprintf("QemuBinary(): Unsupported arch: %s", a))
 	}
 }
 
 // Console returns the name of the device for the first serial port.
-func Console() (string, error) {
-	switch runtime.GOARCH {
+func (a Arch) Console() string {
+	switch a {
 	case "amd64":
-		return "ttyS0", nil
+		return "ttyS0"
 	case "arm64":
-		return "ttyAMA0", nil
+		return "ttyAMA0"
 	default:
-		return "", ErrUnsupportedArch
+		panic(fmt.Sprintf("Console(): Unsupported arch: %s", a))
 	}
 }
 
 // AppendArchSpecificQemuArgs appends Qemu arguments to the input that are
 // specific to the architecture lvh is running on. For example on ARM64, Qemu
 // needs some precision on the -machine option to start.
-func AppendArchSpecificQemuArgs(qemuArgs []string) []string {
-	switch runtime.GOARCH {
+func (a Arch) AppendArchSpecificQemuArgs(qemuArgs []string) []string {
+	switch a {
 	case "arm64":
 		return append(qemuArgs, "-machine", "virt")
-	default:
+	case "amd64":
 		return qemuArgs
+	default:
+		panic(fmt.Sprintf("AppendArchSpecificQemuArgs(): Unsupported arch: %s", a))
 	}
 }
 
 // AppendCPUKind appends the -cpu type if needed, historically amd64 has used no
 // specific kind when running without KVM, and using kvm64 when running with
 // KVM. However, arm64 needs -cpu max in both cases to start properly.
-func AppendCPUKind(qemuArgs []string, kvmEnabled bool, cpuKind string) []string {
+func (a Arch) AppendCPUKind(qemuArgs []string, kvmEnabled bool, cpuKind string) []string {
 	if cpuKind != "" {
 		return append(qemuArgs, "-cpu", cpuKind)
 	}
-	switch runtime.GOARCH {
+	switch a {
 	case "amd64":
 		if kvmEnabled {
 			return append(qemuArgs, "-cpu", "kvm64")
 		}
 	case "arm64":
 		return append(qemuArgs, "-cpu", "max")
+	default:
+		panic(fmt.Sprintf("AppendCPUKind(): Unsupported arch: %s", a))
 	}
 	return qemuArgs
 }
@@ -98,9 +109,9 @@ func AppendCPUKind(qemuArgs []string, kvmEnabled bool, cpuKind string) []string 
 // so option is unconfigured. Typically arm64 should not be bootable by default
 // because we didn't take the time to find a bootloader that was arm64
 // compatible so far.
-func Bootable(bootable *bool) bool {
+func (a Arch) Bootable(bootable *bool) bool {
 	if bootable == nil {
-		return runtime.GOARCH == "amd64"
+		return string(a) == "amd64"
 	}
 	return *bootable
 }

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -30,7 +30,11 @@ func (a Arch) Target() string {
 }
 
 func (a Arch) CrossCompiling() bool {
-	return string(a) != runtime.GOARCH
+	return !a.IsNative()
+}
+
+func (a Arch) IsNative() bool {
+	return string(a) == runtime.GOARCH
 }
 
 func (a Arch) CrossCompileMakeArgs() []string {

--- a/pkg/images/pull.go
+++ b/pkg/images/pull.go
@@ -26,6 +26,7 @@ type PullConf struct {
 	Image     string
 	TargetDir string
 	Cache     bool
+	Platform  string
 }
 
 type ExtractResult struct {
@@ -41,7 +42,9 @@ func PullImage(ctx context.Context, conf PullConf) error {
 	}
 	defer cli.Close()
 
-	remotePullReader, err := cli.ImagePull(ctx, conf.Image, image.PullOptions{})
+	remotePullReader, err := cli.ImagePull(ctx, conf.Image, image.PullOptions{
+		Platform: conf.Platform,
+	})
 	if err != nil {
 		return fmt.Errorf("cannot pull image %s: %w", conf.Image, err)
 	}

--- a/pkg/runner/conf.go
+++ b/pkg/runner/conf.go
@@ -45,6 +45,8 @@ type RunConf struct {
 	RootDev string
 
 	QemuMonitorPort int
+
+	QemuArch string
 }
 
 func (rc *RunConf) testImageFname() string {

--- a/pkg/runner/qemu.go
+++ b/pkg/runner/qemu.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getArch(rcnf *RunConf) (*arch.Arch, error) {
+func getArch(rcnf *RunConf) (arch.Arch, error) {
 	a := rcnf.QemuArch
 	if a == "" {
 		a = runtime.GOARCH

--- a/pkg/runner/qemu.go
+++ b/pkg/runner/qemu.go
@@ -44,7 +44,7 @@ func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 
 	// quick-and-dirty kvm detection
 	kvmEnabled := false
-	if !rcnf.DisableHardwareAccel {
+	if !rcnf.DisableHardwareAccel && qArch.IsNative() {
 		switch runtime.GOOS {
 		case "linux":
 			if f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0755); err == nil {


### PR DESCRIPTION
After this PR, we can do:

```shell
lvh images pull quay.io/lvh-images/kind@sha256:eaa587681844b157a595afb23c1fdcc60f3e8e9a3404a8bd1c826089dc1a89da --platform linux/arm64
lvh kernel pull 5.15-main --platform linux/arm64
lvh run --qemu-arch arm64  --image _data/images/kind_5.10.qcow2 --kernel 5.15-main/boot/vmlinuz-5.15.164
```

To boot an ARM vm on x86. It would be nice to have an `images pull` that works like `kernel pull`, but this is left as a followup.