### PR TITLE
Prepare for v0.0.20 release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ inputs:
   lvh-version:
     description: 'LVH cli version (Docker tag)'
     required: true
-    default: 'v0.0.18'
+    default: 'v0.0.20'
   cmd:
     description: 'Commands to run in a VM (any occurance of "$" within "cmd" must be escaped)'
     required: true


### PR DESCRIPTION
Push out a new `action.yaml` that has https://github.com/cilium/little-vm-helper/pull/353.