### PR TITLE
Action: Handle hyphen in image version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -134,7 +134,7 @@ runs:
       if: ${{ inputs.provision == 'true' }}
       id: derive-image-name
       shell: bash
-      run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/\([^-]*\)\-\(.*\)/\1/g')" >> $GITHUB_OUTPUT
+      run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/^\(.*\)\-[0-9.]*\(\-[^-]*\)*$/\1/g')" >> $GITHUB_OUTPUT
     - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       if: ${{ inputs.provision == 'true' }}
       id: cache-lvh-image


### PR DESCRIPTION
The regex that chops an image version into its name and version assumes there is only one hyphen and that separate the name from the version. The "bpf-next" images break this assumption. This commit changes the regex to handle hyphens in the image name.