### PR TITLE
Action: Handle Cilium image names

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -134,7 +134,7 @@ runs:
       if: ${{ inputs.provision == 'true' }}
       id: derive-image-name
       shell: bash
-      run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/^\(.*\)\-[0-9.]*\(\-[^-]*\)*$/\1/g')" >> $GITHUB_OUTPUT
+      run: echo "image-name=$(echo ${{ inputs.image }} | sed 's/\-ci//g')_$(echo ${{ inputs.image-version }} | sed 's/^\(.*\)\-[0-9.]*\(\-[^-]*\)*\(@sha256:.*\)*$/\1/g'" >> $GITHUB_OUTPUT
     - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       if: ${{ inputs.provision == 'true' }}
       id: cache-lvh-image


### PR DESCRIPTION
Image names such as bpf-next-20250110.013326@sha256:foo also need to parse to bpf-next in action.yaml. This commit updates the regex.