### PR TITLE
Prepare for v0.0.23 release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ inputs:
   lvh-version:
     description: 'LVH cli version (Docker tag)'
     required: true
-    default: 'v0.0.22'
+    default: 'v0.0.23'
   cmd:
     description: 'Commands to run in a VM (any occurance of "$" within "cmd" must be escaped)'
     required: true


### PR DESCRIPTION
Pick up https://github.com/cilium/little-vm-helper/pull/364.