### PR TITLE
Fix Go 1.24 non-constant format string errors

### DIFF
--- a/pkg/images/build_test.go
+++ b/pkg/images/build_test.go
@@ -18,7 +18,7 @@ type testLogger struct {
 }
 
 func (tl testLogger) Write(p []byte) (n int, err error) {
-	tl.Logf((string)(p))
+	tl.Log((string)(p))
 	return len(p), nil
 }
 

--- a/pkg/kernels/kernels_test.go
+++ b/pkg/kernels/kernels_test.go
@@ -17,7 +17,7 @@ type testLogger struct {
 }
 
 func (tl testLogger) Write(p []byte) (n int, err error) {
-	tl.Logf((string)(p))
+	tl.Log((string)(p))
 	return len(p), nil
 }
 


### PR DESCRIPTION
Starting with Go 1.24 we'll see the following errors on `go test`:

```
go test -cover ./...
	github.com/cilium/little-vm-helper/cmd/lvh		coverage: 0.0% of statements
	github.com/cilium/little-vm-helper/cmd/lvh/images		coverage: 0.0% of statements
	github.com/cilium/little-vm-helper/cmd/lvh/kernels		coverage: 0.0% of statements
	github.com/cilium/little-vm-helper/cmd/lvh/runner		coverage: 0.0% of statements
	github.com/cilium/little-vm-helper/pkg/arch		coverage: 0.0% of statements
Error: pkg/images/build_test.go:21:10: non-constant format string in call to (*testing.common).Logf FAIL	github.com/cilium/little-vm-helper/pkg/images [build failed] Error: pkg/kernels/kernels_test.go:20:10: non-constant format string in call to (*testing.common).Logf FAIL	github.com/cilium/little-vm-helper/pkg/kernels [build failed] ok  	github.com/cilium/little-vm-helper/pkg/logcmd	0.111s	coverage: 79.5% of statements
	github.com/cilium/little-vm-helper/pkg/runner		coverage: 0.0% of statements
	github.com/cilium/little-vm-helper/pkg/step		coverage: 0.0% of statements
?   	github.com/cilium/little-vm-helper/pkg/version	[no test files]
FAIL
```

Fix these by using `testing.T.Log` instead.