### PR TITLE
runner: set platform flag when pulling image

### DIFF
--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -46,6 +46,7 @@ func RunCommand() *cobra.Command {
 				pcnf := images.PullConf{
 					Image:     rcnf.Image,
 					TargetDir: dirName,
+					Platform:  rcnf.QemuArch,
 				}
 				// Not a local file reference, could this be an OCI image?
 				if err := images.PullImage(context.Background(), pcnf); err != nil {


### PR DESCRIPTION
If the runner needs to pull an image, set the platform flag according to the specified qemu-arch. This enables you to run cross-arch images without the friction of needing to first pull them separately. For example, the following now works on an amd64 host:

    sudo lvh run --image quay.io/lvh-images/kind:5.15-main-arm64 -p 38141:22 --qemu-arch arm64