### PR TITLE
Makefile: set version in binary built during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ image:
 
 .PHONY: install
 install:
-	GOARCH=${TARGET_ARCH} CGO_ENABLED=0 $(GO) install ./cmd/lvh
+	GOARCH=${TARGET_ARCH} CGO_ENABLED=0 $(GO) install $(GO_BUILD_FLAGS) ./cmd/lvh
 
 clean:
 	rm -f lvh


### PR DESCRIPTION
Provide the Go build flags on installation as well. Otherwise the `lvh` binary built using `make install` won't report the version.

Before:

```
$ make install
GOARCH=amd64 CGO_ENABLED=0 go install ./cmd/lvh
$ lvh version

$
```

After:

```
$ make install
GOARCH=amd64 CGO_ENABLED=0 go install -ldflags "-X 'github.com/cilium/little-vm-helper/pkg/version.Version=v0.0.23-78-g8619b8615495'" ./cmd/lvh $ lvh version
v0.0.23-78-g8619b8615495
$
```