### PR TITLE
action.yaml: Fix the default kernel-version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -76,7 +76,7 @@ inputs:
   kernel-version:
     description: 'Kernel version (if empty, a kernel from the image will be used)'
     required: false
-    default: 'false'
+    default: ''
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Otherwise, it will try to fetch a kernel with the "false" tag. The empty value is the correct default.

Also, fix the caching key.