### PR TITLE
action: use PATH to find lvh binary

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -182,7 +182,7 @@ runs:
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        /bin/lvh images pull --platform linux/${{ inputs.arch}} --cache quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} --dir "${{ inputs.images-folder-parent }}/images/${{ inputs.arch }}/"
+        lvh images pull --platform linux/${{ inputs.arch}} --cache quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} --dir "${{ inputs.images-folder-parent }}/images/${{ inputs.arch }}/"
         find ${{ inputs.images-folder-parent }}/images/${{ inputs.arch }}/ -type f -exec sudo chmod 666 {} +
         find ${{ inputs.images-folder-parent }}/images/${{ inputs.arch }}
 
@@ -198,7 +198,7 @@ runs:
       if: ${{ inputs.provision == 'true' && inputs.kernel-version != '' && steps.cache-lvh-kernel.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        /bin/lvh kernel pull --platform=linux/${{ inputs.arch }} --dir "${{ inputs.images-folder-parent }}/kernels/${{ inputs.arch }}" ${{ inputs.kernel-version }}
+        lvh kernel pull --platform=linux/${{ inputs.arch }} --dir "${{ inputs.images-folder-parent }}/kernels/${{ inputs.arch }}" ${{ inputs.kernel-version }}
 
     - name: Set kernel path
       id: kernel-path
@@ -243,7 +243,7 @@ runs:
           MEM="$(free -m | awk '/^Mem:/{print int($2 * 0.75)}')M"
           echo "mem unspecified, defaulting ot 75% of host memory: $MEM"
         fi
-        sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image ${{ inputs.images-folder-parent }}/images/${{ inputs.arch }}/images/${{ steps.derive-image-name.outputs.image-name }}.qcow2 \
+        sudo lvh run --host-mount=${{ inputs.host-mount }} --image ${{ inputs.images-folder-parent }}/images/${{ inputs.arch }}/images/${{ steps.derive-image-name.outputs.image-name }}.qcow2 \
             --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }} \
             --cpu=$CPU --mem=$MEM \
             --console-log-file /tmp/console.log \


### PR DESCRIPTION
Action was broken when installing LVH manually, with go install for example, not using the action self install mechanism which installs in /bin/lvh because of hardcoded absolute binary path.