### PR TITLE
image build: add cli arg to select the package repository when making root images

### DIFF
--- a/cmd/lvh/images/build.go
+++ b/cmd/lvh/images/build.go
@@ -16,7 +16,7 @@ import (
 )
 
 func BuildCmd() *cobra.Command {
-	var dirName string
+	var dirName, pkgRepository string
 	var forceRebuild, dryRun, mergeSteps bool
 	var imageNames []string
 
@@ -54,6 +54,7 @@ func BuildCmd() *cobra.Command {
 				DryRun:       dryRun,
 				ForceRebuild: forceRebuild,
 				MergeSteps:   mergeSteps,
+				PkgRepo:      pkgRepository,
 			}
 			start := time.Now()
 			if imageNames == nil {
@@ -86,5 +87,6 @@ func BuildCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&forceRebuild, "force-rebuild", false, "rebuild all images, even if they exist")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "do the whole thing, but instead of building actual images create empty files")
 	cmd.Flags().BoolVar(&mergeSteps, "merge-steps", true, "Merge steps when possible to improve performance. Disabling this might be useufl to investigate action issues.")
+	cmd.Flags().StringVar(&pkgRepository, "pkg-repo", "sid", "repository used to get packages from when building a base image (ex: sid, unstable, bookworm, stable, oldstable, etc..)")
 	return cmd
 }

--- a/pkg/images/build.go
+++ b/pkg/images/build.go
@@ -22,6 +22,10 @@ type BuildConf struct {
 	ForceRebuild bool
 	// if MergeSteps is set, image build steps will be merged when possible (better performance at the cost making operations more complicated)
 	MergeSteps bool
+
+	// PkgRepo is from which release branch (ex: sid, buster, bookworm, stable)
+	// to use for installing packages during bootstrap
+	PkgRepo string
 }
 
 // BuildImageResult describes the result of building a single image
@@ -149,7 +153,7 @@ func (b *buildState) doBuildImage(image string) BuildImageResult {
 	}
 
 	buildImage := func(image string) error {
-		return b.f.doBuildImage(context.Background(), b.bldConf.Log, image, b.bldConf.MergeSteps)
+		return b.f.doBuildImage(context.Background(), b.bldConf.Log, image, b.bldConf.MergeSteps, b.bldConf.PkgRepo)
 	}
 	if b.bldConf.DryRun {
 		buildImage = b.f.doBuildImageDryRun

--- a/pkg/images/image_build.go
+++ b/pkg/images/image_build.go
@@ -48,6 +48,7 @@ func (f *ImageForest) doBuildImage(
 	log *logrus.Logger,
 	image string,
 	merge bool,
+	pkgRepository string,
 ) error {
 	cnf, ok := f.confs[image]
 	if !ok {
@@ -62,7 +63,7 @@ func (f *ImageForest) doBuildImage(
 
 	steps := make([]step.Step, 2, 2+len(cnf.Actions))
 
-	steps[0] = NewCreateImage(stepConf)
+	steps[0] = NewCreateImage(stepConf, pkgRepository)
 	// NB: We might need an --chdir option or similar, but for now just
 	// chdir to the the base dir.
 	baseDir, path := filepath.Split(f.imagesDir)

--- a/pkg/images/step_create_image.go
+++ b/pkg/images/step_create_image.go
@@ -52,11 +52,15 @@ var (
 
 type CreateImage struct {
 	*StepConf
+	// PkgRepo is from which release branch (ex: sid, buster, bookworm, stable)
+	// to use for installing packages during bootstrap
+	PkgRepo string
 }
 
-func NewCreateImage(cnf *StepConf) *CreateImage {
+func NewCreateImage(cnf *StepConf, pkgRepository string) *CreateImage {
 	return &CreateImage{
 		StepConf: cnf,
+		PkgRepo:  pkgRepository,
 	}
 }
 
@@ -89,7 +93,7 @@ func (s *CreateImage) makeRootImage(ctx context.Context) error {
 	packages = append(packages, s.imgCnf.Packages...)
 
 	cmd := exec.CommandContext(ctx, Mmdebstrap,
-		"sid",
+		s.PkgRepo,
 		"--include", strings.Join(packages, ","),
 		tarFname,
 	)


### PR DESCRIPTION
with sid, we got a newer systemd that caused rhel8.6 to break. 
adding a command so we can pick which release branch to use