### PR TITLE
Dockerfile: fix FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.3@sha256:6ea52a02734dd15e943286b048278da1e04eca196a564578d718c7720433dbbe as gobuilder
+FROM --platform=$BUILDPLATFORM golang:1.25.3@sha256:6ea52a02734dd15e943286b048278da1e04eca196a564578d718c7720433dbbe AS gobuilder
 WORKDIR /src/little-vm-helper
 COPY . .
 ARG TARGETARCH


### PR DESCRIPTION
Fix the following warning emitted on docker build:

    1 warning found (use docker --debug to expand):
    - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)