### PR TITLE
Fix typo: succesfully -> successfully in image build logs

### DIFF
--- a/cmd/lvh/images/build.go
+++ b/cmd/lvh/images/build.go
@@ -68,7 +68,7 @@ func BuildCmd() *cobra.Command {
 			if err != nil {
 				log.WithError(err).Error("building images failed")
 			} else {
-				log.WithField("time-elapsed", elapsed).Info("images built succesfully")
+				log.WithField("time-elapsed", elapsed).Info("images built successfully")
 			}
 
 			for img, ir := range res.ImageResults {

--- a/pkg/images/build.go
+++ b/pkg/images/build.go
@@ -68,7 +68,7 @@ func (f *ImageForest) BuildImage(bldConf *BuildConf, image string) (*BuilderResu
 			"result":   fmt.Sprintf("%+v", imgRes),
 		})
 		if imgRes.Error == nil {
-			xlog.Info("image built succesfully")
+			xlog.Info("image built successfully")
 		} else {
 			xlog.Warn("image build failed")
 			break
@@ -110,7 +110,7 @@ func (f *ImageForest) BuildImages(bldConf *BuildConf, queue []string) *BuilderRe
 			"result": fmt.Sprintf("%+v", imgRes),
 		})
 		if imgRes.Error == nil {
-			xlog.Info("image built succesfully")
+			xlog.Info("image built successfully")
 		} else {
 			xlog.Warn("image build failed")
 		}


### PR DESCRIPTION
Corrects the misspelling 'succesfully' to 'successfully' in three image build log messages.