### PR TITLE
action: Add retries for docker pull

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -147,6 +147,15 @@ runs:
       if: ${{ inputs.provision == 'true' && steps.find-lvh-cli.outputs.skip != 'true' }}
       shell: bash
       run: |
+        success=0
+        for n in {1..5}; do
+          if docker pull quay.io/lvh-images/lvh:${{ inputs.lvh-version }}; then
+            success=1
+            break;
+          fi
+          sleep $((n+1))
+        done
+        [ $success -eq 1 ] || exit 42
         cid=$(docker create quay.io/lvh-images/lvh:${{ inputs.lvh-version }})
         docker cp $cid:/usr/bin/lvh /tmp/lvh
         docker rm $cid


### PR DESCRIPTION
When creating a docker container, we may occasionally hit temporary
infrastructure issues like the following:

    Unable to find image 'quay.io/lvh-images/lvh:v0.0.29' locally
    v0.0.29: Pulling from lvh-images/lvh
    received unexpected HTTP status: 504 Gateway Time-out

Similar to commit 657fd0df35e4 ("action.yaml: Add retry when fetching
dependencies"), add a retry in the docker pull as well.