### PR TITLE
fix: create parent dirs when extracting pulled kernels

### DIFF
--- a/cmd/lvh/kernels/pull.go
+++ b/cmd/lvh/kernels/pull.go
@@ -149,14 +149,20 @@ func ExtractTarPath(tarFile string, path string, targetDir string) error {
 				return fmt.Errorf("failed to create directory %s: %w", dstPath, err)
 			}
 		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+				return fmt.Errorf("failed to create parent directory for %s: %w", dstPath, err)
+			}
 			dstFile, err := os.Create(dstPath)
 			if err != nil {
 				return fmt.Errorf("failed to open %s: %w", dstPath, err)
 			}
-			defer dstFile.Close()
 			n, err := io.CopyN(dstFile, tarReader, header.Size)
+			closeErr := dstFile.Close()
 			if err != nil {
 				return fmt.Errorf("failed to copy %s from tar %s: %w", dstPath, tarFile, err)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("failed to close %s: %w", dstPath, closeErr)
 			}
 			if n != header.Size {
 				return fmt.Errorf("tar header reports file %s size %d, but only %d bytes were pulled", header.Name, header.Size, n)

--- a/cmd/lvh/kernels/pull_test.go
+++ b/cmd/lvh/kernels/pull_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kernels
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractTarPathCreatesParentDirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	tarPath := filepath.Join(dir, "kernel.tar")
+	file, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatalf("create tar: %v", err)
+	}
+
+	tw := tar.NewWriter(file)
+	content := []byte("kernel")
+	header := &tar.Header{
+		Name: "data/kernels/6.6-main/boot/vmlinuz-6.6.0",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write file content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close tar file: %v", err)
+	}
+
+	targetDir := filepath.Join(dir, "out")
+	if err := ExtractTarPath(tarPath, "data/kernels/6.6-main", targetDir); err != nil {
+		t.Fatalf("extract tar path: %v", err)
+	}
+
+	extracted := filepath.Join(targetDir, "boot", "vmlinuz-6.6.0")
+	got, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("read extracted file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("unexpected extracted content: got %q want %q", got, content)
+	}
+}


### PR DESCRIPTION
This fixes a small sharp edge in `lvh kernels pull`.

Some tar archives, including OCI-style layers, do not contain explicit directory entries. In that case `ExtractTarPath()` blows up with `no such file or directory` while writing `boot/vmlinuz-*`.

Repro:
```bash
tmp=$(mktemp -d)
mkdir -p "$tmp/data/kernels/6.6-main/boot"
echo kernel > "$tmp/data/kernels/6.6-main/boot/vmlinuz-6.6.0"
tar -C "$tmp" -cf "$tmp/kernel.tar" data/kernels/6.6-main/boot/vmlinuz-6.6.0
tar -tf "$tmp/kernel.tar"
```

Before this patch, extracting that tar fails because `boot/` was never created.

The fix just creates parent dirs before writing regular files, and adds a regression test. Pretty small, but it makes the extractor less brittle.
