### PR TITLE
fix: reject cyclic image parent configurations

### DIFF
--- a/pkg/images/forest.go
+++ b/pkg/images/forest.go
@@ -41,6 +41,33 @@ func NewImageForest(conf *ImagesConf, saveConfFile bool) (*ImageForest, error) {
 		}
 	}
 
+	visited := make(map[string]uint8, len(confs))
+	var visitParent func(string) error
+	visitParent = func(image string) error {
+		switch visited[image] {
+		case 1:
+			return fmt.Errorf("cyclic image parent relationship involving %q", image)
+		case 2:
+			return nil
+		}
+
+		visited[image] = 1
+		if parent, ok := parent[image]; ok {
+			if _, ok := confs[parent]; ok {
+				if err := visitParent(parent); err != nil {
+					return err
+				}
+			}
+		}
+		visited[image] = 2
+		return nil
+	}
+	for image := range confs {
+		if err := visitParent(image); err != nil {
+			return nil, err
+		}
+	}
+
 	// using the parent map, form the children map
 	children := make(map[string][]string)
 	for child, parent := range parent {

--- a/pkg/images/forest_test.go
+++ b/pkg/images/forest_test.go
@@ -39,6 +39,26 @@ func TestImageBuilderConfs(t *testing.T) {
 		},
 		{
 			confs: []ImgConf{
+				{Name: "image1", Parent: "image2"},
+				{Name: "image2", Parent: "image1"},
+			},
+			test: func(f *ImageForest, err error) {
+				assert.Nil(t, f)
+				assert.ErrorContains(t, err, "cyclic image parent relationship")
+			},
+		},
+		{
+			confs: []ImgConf{
+				{Name: "image", Parent: "external-base"},
+			},
+			test: func(f *ImageForest, err error) {
+				assert.NotNil(t, f)
+				assert.Nil(t, err)
+				assert.Equal(t, []string{"image"}, f.RootImages())
+			},
+		},
+		{
+			confs: []ImgConf{
 				{Name: "base"},
 				{Name: "image1", Parent: "base"},
 				{Name: "image2", Parent: "image1"},


### PR DESCRIPTION
Fixes a parent cycle that could make `images build` finish with no images, or loop forever for a selected image

Repro:
`[{"name":"a.qcow2","parent":"b.qcow2"},{"name":"b.qcow2","parent":"a.qcow2"}]`

Run `lvh images build` with this config. It now fails clearly. External parent images still work, tests cover both