### PR TITLE
runner: add --kernel-modules flag to expose host kernel modules to the guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ go run ./cmd/lvh run --image _data/images/base.img
 > - `--host-mount` to mount your working directory, making applying changes and
 >   testing them quicker (be aware that it requires kernel modules to load
 >   correctly).
+> - `--kernel-modules` to expose a directory of kernel modules matching a
+>   custom `--kernel` under the `kernel_modules` 9p tag, so you don't have to
+>   rebuild the VM image. Mount it inside the guest, e.g. `mount -t 9p -o
+>   trans=virtio,version=9p2000.L kernel_modules /lib/modules/$(uname -r)`.
 > - `--cpu` and `--mem` to adjust the specs for the VM, making building and
 >   running inside the VM quicker.
 >

--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -89,6 +89,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&rcnf.Daemonize, "daemonize", false, "daemonize QEMU after initializing")
 	cmd.Flags().StringVar(&rcnf.ConsoleLogFile, "console-log-file", "", "Save VM console output to given file")
 	cmd.Flags().StringVar(&rcnf.HostMount, "host-mount", "", "Mount the specified host directory in the VM using a 'host_mount' tag")
+	cmd.Flags().StringVar(&rcnf.KernelModulesDir, "kernel-modules", "", "Expose the specified host directory of kernel modules to the VM using a 'kernel_modules' tag, for use alongside --kernel")
 	cmd.Flags().StringArrayVarP(&ports, "port", "p", nil, "Forward a port (hostport[:vmport[:tcp|udp]])")
 	cmd.Flags().IntVar(&rcnf.SerialPort, "serial-port", 0, "Port for serial console")
 	cmd.Flags().IntVar(&rcnf.CPU, "cpu", 2, "CPU count (-smp)")

--- a/pkg/runner/conf.go
+++ b/pkg/runner/conf.go
@@ -34,6 +34,11 @@ type RunConf struct {
 
 	HostMount string
 
+	// KernelModulesDir is a host directory of kernel modules to expose to
+	// the guest, for use with a custom --kernel whose modules are not
+	// present in the VM image.
+	KernelModulesDir string
+
 	SerialPort int
 
 	CPU int

--- a/pkg/runner/qemu.go
+++ b/pkg/runner/qemu.go
@@ -129,6 +129,13 @@ func BuildQemuArgs(log slogger.Logger, rcnf *RunConf) ([]string, error) {
 		)
 	}
 
+	if len(rcnf.KernelModulesDir) > 0 {
+		qemuArgs = append(qemuArgs,
+			"-fsdev", fmt.Sprintf("local,id=kernel_modules_id,path=%s,security_model=none,readonly=on", rcnf.KernelModulesDir),
+			"-device", "virtio-9p-pci,fsdev=kernel_modules_id,mount_tag=kernel_modules",
+		)
+	}
+
 	return qemuArgs, nil
 }
 

--- a/pkg/runner/qemu_test.go
+++ b/pkg/runner/qemu_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/cilium/little-vm-helper/pkg/slogger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildQemuArgsKernelModules(t *testing.T) {
+	rcnf := RunConf{
+		Image:            "image.qcow2",
+		RootDev:          "vda",
+		CPU:              1,
+		Mem:              "1G",
+		Daemonize:        true,
+		KernelModulesDir: "/host/modules",
+	}
+
+	args, err := BuildQemuArgs(slogger.NewDiscard(), &rcnf)
+	assert.Nil(t, err)
+	assert.Contains(t, args, "-fsdev")
+	assert.Contains(t, args, "local,id=kernel_modules_id,path=/host/modules,security_model=none,readonly=on")
+	assert.Contains(t, args, "-device")
+	assert.Contains(t, args, "virtio-9p-pci,fsdev=kernel_modules_id,mount_tag=kernel_modules")
+}
+
+func TestBuildQemuArgsNoKernelModules(t *testing.T) {
+	rcnf := RunConf{
+		Image:     "image.qcow2",
+		RootDev:   "vda",
+		CPU:       1,
+		Mem:       "1G",
+		Daemonize: true,
+	}
+
+	args, err := BuildQemuArgs(slogger.NewDiscard(), &rcnf)
+	assert.Nil(t, err)
+	assert.NotContains(t, args, "virtio-9p-pci,fsdev=kernel_modules_id,mount_tag=kernel_modules")
+}


### PR DESCRIPTION
## What

Adds a `--kernel-modules <dir>` flag to `lvh run`, for use alongside
`--kernel`. It exposes the given host directory to the guest as a second
virtio-9p share (read-only, tag `kernel_modules`), the same mechanism
`--host-mount` already uses for the `host_mount` tag.

## Why

Fixes #117. `--kernel` lets you boot a custom kernel, but the guest still
sees whatever `/lib/modules` shipped in the VM image, which fails to load
if it doesn't match the custom kernel's version. The only existing
workaround is mounting the full Linux source tree with `--host-mount` and
running `make module_install` inside the guest, which is slow and requires
the guest to have a working build toolchain. This flag lets you point at a
directory of already-built modules instead.

## Design notes

Credit where due: `SAMurai-16` sketched this approach first, in a design
proposal posted on issue #117 (a `--kernel-modules` option that exposes the
directory to the guest at runtime via a share, matching the custom
`--kernel`). They never opened a PR, but the mechanism below follows what
they proposed there.

This mirrors `--host-mount` exactly (same `-fsdev`/`-device` qemu argument
pair, new tag) rather than two alternatives I considered and rejected:

- Auto-mounting inside the guest via a baked-in fstab entry: the fstab
  entry that makes `--host-mount` land at `/host` lives in the separate
  `cilium/little-vm-helper-images` repo (`_data/bootstrap/fstab.sh`), not
  here, so this repo has no way to guarantee where `kernel_modules` should
  auto-mount without a matching change there. Out of scope for this PR.
- Baking modules into the initramfs/image at build time: much larger
  surface, touches image-build machinery, and reintroduces the "rebuild
  the image" cost this feature exists to avoid.

The share is mounted read-only (`readonly=on`) since the guest only needs
to read modules, never write them back.

Mount it inside the guest the same way you would `--host-mount`:
```
mount -t 9p -o trans=virtio,version=9p2000.L kernel_modules /lib/modules/$(uname -r)
```

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Added `pkg/runner/qemu_test.go` covering `BuildQemuArgs` with and without
  `--kernel-modules` set, checking the exact qemu args produced.
- Not tested against a real booted VM: this sandbox has no KVM/hardware
  acceleration available, and the `runner` package had no VM-boot
  integration tests before this change to extend. Argument construction is
  the same altitude this package was tested at previously (not tested at
  all, in fact, since this PR adds its first unit tests for
  `BuildQemuArgs`).

## AI disclosure

Per the Cilium Generative AI Policy: I used Claude (Anthropic) to help
draft this change, including exploring the existing `--host-mount`
implementation, writing the flag/config/qemu-arg plumbing, and drafting the
unit test. I reviewed the diff line by line, ran the build/vet/test
commands myself locally, and take full responsibility for the change as
submitted.
