### PR TITLE
run: add --append option to pass kernel cmdline args

### DIFF
--- a/cmd/lvh/runner/runner.go
+++ b/cmd/lvh/runner/runner.go
@@ -98,6 +98,7 @@ func RunCommand() *cobra.Command {
 	cmd.Flags().StringVar(&rcnf.RootDev, "root-dev", "vda", "type of root device (hda or vda)")
 	cmd.Flags().BoolVarP(&rcnf.Verbose, "verbose", "v", false, "Print qemu command before running it")
 	cmd.Flags().StringVar(&rcnf.QemuArch, "qemu-arch", runtime.GOARCH, "specify qemu arch to use")
+	cmd.Flags().StringArrayVar(&rcnf.KernelAppendArgs, "append", nil, "Append kernel command line parameters (use in combination with --kernel)")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes #716 

This is useful when running with a custom kernel that is for example misconfigured and doesn't start with bpf lsm.